### PR TITLE
fix type incompatibility by replacing MessageParamContentUnion with ContentBlockParamUnion

### DIFF
--- a/examples/tools-streaming-jsonschema/main.go
+++ b/examples/tools-streaming-jsonschema/main.go
@@ -76,7 +76,7 @@ func main() {
 		}
 
 		messages = append(messages, message.ToParam())
-		toolResults := []anthropic.MessageParamContentUnion{}
+		toolResults := []anthropic.ContentBlockParamUnion{}
 
 		for _, block := range message.Content {
 			if block.Type == anthropic.ContentBlockTypeToolUse {

--- a/examples/tools-streaming/main.go
+++ b/examples/tools-streaming/main.go
@@ -108,7 +108,7 @@ func main() {
 		}
 
 		messages = append(messages, message.ToParam())
-		toolResults := []anthropic.MessageParamContentUnion{}
+		toolResults := []anthropic.ContentBlockParamUnion{}
 
 		for _, block := range message.Content {
 			if block.Type == anthropic.ContentBlockTypeToolUse {

--- a/examples/tools/main.go
+++ b/examples/tools/main.go
@@ -96,7 +96,7 @@ func main() {
 		println()
 
 		messages = append(messages, message.ToParam())
-		toolResults := []anthropic.MessageParamContentUnion{}
+		toolResults := []anthropic.ContentBlockParamUnion{}
 
 		for _, block := range message.Content {
 			if block.Type == anthropic.ContentBlockTypeToolUse {


### PR DESCRIPTION
### Description:
The Go script was failing due to the use of the `MessageParamContentUnion` type. The SDK has since updated, and the correct type to use is `ContentBlockParamUnion`. This change ensures that the script can run successfully without type-related errors.

### Changes:
- Replaced `MessageParamContentUnion` with `ContentBlockParamUnion`.

### Impact:
This fix resolves the compatibility issue and allows the Go script to execute without errors.

Please review and merge the changes.
