### PR TITLE
fix(messages): accumulate thinking/signature fields

### DIFF
--- a/message.go
+++ b/message.go
@@ -1180,6 +1180,14 @@ func (r *Message) ToParam() MessageParam {
 				Value:   block.Input,
 				Present: len(block.Input) > 0 && !block.JSON.Input.IsNull(),
 			},
+			Thinking: param.Field[string]{
+				Value:   block.Thinking,
+				Present: !block.JSON.Thinking.IsNull(),
+			},
+			Signature: param.Field[string]{
+				Value:   block.Signature,
+				Present: !block.JSON.Signature.IsNull(),
+			},
 		})
 	}
 

--- a/thinking_test.go
+++ b/thinking_test.go
@@ -1,0 +1,34 @@
+package anthropic
+
+import (
+	"testing"
+)
+
+func TestThinkingAndSignaturePreserved(t *testing.T) {
+	// Create a simple Message with Content containing Thinking and Signature
+	msg := &Message{
+		Role: MessageRoleAssistant,
+		Content: []ContentBlock{
+			{
+				Type:      ContentBlockTypeText,
+				Text:      "Hello world",
+				Thinking:  "This is a thinking block",
+				Signature: "This is a signature",
+			},
+		},
+	}
+
+	// Convert to MessageParam
+	param := msg.ToParam()
+
+	// Check if Thinking and Signature fields are preserved
+	contentBlockParam := param.Content.Value[0].(ContentBlockParam)
+
+	if contentBlockParam.Thinking.Value != "This is a thinking block" {
+		t.Errorf("Expected Thinking value to be 'This is a thinking block', got %q", contentBlockParam.Thinking.Value)
+	}
+
+	if contentBlockParam.Signature.Value != "This is a signature" {
+		t.Errorf("Expected Signature value to be 'This is a signature', got %q", contentBlockParam.Signature.Value)
+	}
+}


### PR DESCRIPTION

When converting a Message to MessageParam using the ToParam() method, the thinking and signature fields were not being preserved. This causes problems with the extended thinking feature, as thinking content is lost when messages are converted for subsequent API calls.

The fix adds these missing fields to the ContentBlockParam creation in the ToParam() method and includes a test to verify the fields are preserved.