### PR TITLE
Scripts update lint

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,2 @@
 brew "go"
+brew "golangci-lint"

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Running Go build"
+go build ./...

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-echo "==> Running Go build"
-go build ./...
+echo "==> Running Go linters"
+golangci-lint run ./...


### PR DESCRIPTION
In the Setting the environment section of the contribution page there was an extra script which didn't exists, `./scripts/build` . The lint file had a build configuration which replaced with the correct script and added a build script.