### PR TITLE
Fix URL escaping to support Amazon Bedrock inference profiles

### DIFF
--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -209,14 +209,15 @@ func bedrockMiddleware(signer *v4.Signer, cfg aws.Config) option.Middleware {
 				body, _ = sjson.DeleteBytes(body, "model")
 				body, _ = sjson.DeleteBytes(body, "stream")
 
-				var path string
+				var method string
 				if stream {
-					path = fmt.Sprintf("/model/%s/invoke-with-response-stream", url.QueryEscape(model))
+					method = "invoke-with-response-stream"
 				} else {
-					path = fmt.Sprintf("/model/%s/invoke", url.QueryEscape(model))
+					method = "invoke"
 				}
 
-				r.URL.RawPath = path
+				r.URL.Path = fmt.Sprintf("/model/%s/%s", model, method)
+				r.URL.RawPath = fmt.Sprintf("/model/%s/%s", url.QueryEscape(model), method)
 			}
 
 			reader := bytes.NewReader(body)

--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -211,12 +211,12 @@ func bedrockMiddleware(signer *v4.Signer, cfg aws.Config) option.Middleware {
 
 				var path string
 				if stream {
-					path = fmt.Sprintf("/model/%s/invoke-with-response-stream", model)
+					path = fmt.Sprintf("/model/%s/invoke-with-response-stream", url.QueryEscape(model))
 				} else {
-					path = fmt.Sprintf("/model/%s/invoke", model)
+					path = fmt.Sprintf("/model/%s/invoke", url.QueryEscape(model))
 				}
 
-				r.URL.Path = path
+				r.URL.RawPath = path
 			}
 
 			reader := bytes.NewReader(body)


### PR DESCRIPTION
Amazon Bedrock allows to create Inference Profiles, which are very useful for certain scenarios, such as cost tracking. They allow to setup distinct inference profiles for different apps, running on same account, that allows to see their consumptions separately in billing reports.

Inference profile has ARN which looks like `arn:aws:bedrock:us-east-1:947XXXXXX126:application-inference-profile/xv9xxxxxgu4b`, that should be URL-encoded when passed to the Bedrock, otherwise "/" symbol in the name will be contributing to path segments and Amazon will raise an error.

In fact, model names shall be encoded as well, but that doesn't break now because AWS model names do not contain "/" symbol.

This PR fixes escaping that is necessary to use inference profiles.