### PR TITLE
fix(client): accumulate empty tool inputs and citation deltas

### DIFF
--- a/betamessage.go
+++ b/betamessage.go
@@ -757,7 +757,7 @@ func BetaContentBlockParamOfText(text string) BetaContentBlockParamUnion {
 }
 
 func BetaContentBlockParamOfImage[
-T BetaBase64ImageSourceParam | BetaURLImageSourceParam,
+	T BetaBase64ImageSourceParam | BetaURLImageSourceParam,
 ](source T) BetaContentBlockParamUnion {
 	var image BetaImageBlockParam
 	switch v := any(source).(type) {
@@ -805,7 +805,7 @@ func BetaContentBlockParamOfToolResult(toolUseID string) BetaContentBlockParamUn
 }
 
 func BetaContentBlockParamOfDocument[
-T BetaBase64PDFSourceParam | BetaPlainTextSourceParam | BetaContentBlockSourceParam | BetaURLPDFSourceParam,
+	T BetaBase64PDFSourceParam | BetaPlainTextSourceParam | BetaContentBlockSourceParam | BetaURLPDFSourceParam,
 ](source T) BetaContentBlockParamUnion {
 	var document BetaBase64PDFBlockParam
 	switch v := any(source).(type) {

--- a/message.go
+++ b/message.go
@@ -2369,7 +2369,7 @@ func (acc *Message) Accumulate(event MessageStreamEventUnion) error {
 			citation := TextCitationUnion{}
 			err := citation.UnmarshalJSON([]byte(delta.Citation.RawJSON()))
 			if err != nil {
-				return fmt.Errorf("could not unmarshal citation delta into citation type", err)
+				return fmt.Errorf("could not unmarshal citation delta into citation type: %w", err)
 			}
 			cb.Citations = append(cb.Citations, citation)
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -4,13 +4,13 @@ package anthropic_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"os"
-	"testing"
-
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/internal/testutil"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"os"
+	"testing"
 )
 
 func TestMessageNewWithOptionalParams(t *testing.T) {
@@ -160,5 +160,171 @@ func TestMessageCountTokensWithOptionalParams(t *testing.T) {
 			t.Log(string(apierr.DumpRequest(true)))
 		}
 		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}
+
+func TestAccumulate(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		expected anthropic.Message
+		events   []string
+	}{
+		"empty message": {
+			startingMessage: anthropic.Message{},
+			expected:        anthropic.Message{Usage: anthropic.Usage{}},
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type: "message_stop"}`,
+			},
+		},
+		"text content block": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": "This "}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "is a "}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta": "text": "text block!"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "text", Text: "This is a text block!"},
+			}},
+		},
+		"text content block with citations": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": "1 + 1"}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " = 2"}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "citations_delta", "citation": {"type": "char_location", "cited_text": "1 + 1 = 2", "document_index": 0, "document_title": "Math Facts", "start_char_index": 300, "end_char_index": 310 }}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "text", Text: "1 + 1 = 2", Citations: []anthropic.TextCitationUnion{{
+					Type:           "char_location",
+					CitedText:      "1 + 1 = 2",
+					DocumentIndex:  0,
+					DocumentTitle:  "Math Facts",
+					StartCharIndex: 300,
+					EndCharIndex:   310,
+				}}},
+			}},
+		},
+		"tool use block": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"argument\":"}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": " \"value\"}"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "tool_use", ID: "toolu_id", Name: "tool_name", Input: []byte(`{"argument": "value"}`)},
+			}},
+		},
+		"tool use block with no params": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start": "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", input: {}}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": ""}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "tool_use", ID: "toolu_id", Name: "tool_name"},
+			}},
+		},
+		"server tool use block": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start": "index": 0, "content_block": {"type": "server_tool_use", "id": "srvtoolu_id", "name": "web_search", input: {}}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": ""}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"query\": \"weat"}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "her\"}"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "server_tool_use", ID: "srvtoolu_id", Name: "web_search", Input: []byte(`{"query": "weather"}`)},
+			}},
+		},
+		"thinking block": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": "Let me think..."}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "
+First, let's try this..."}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "
+Therefore, the answer is..."}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "ThinkingSignature"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "thinking", Thinking: "Let me think...\nFirst, let's try this...\nTherefore, the answer is...", Signature: "ThinkingSignature"},
+			}},
+		},
+		"redacted thinking block": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "redacted_thinking", "data": "Redacted"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "redacted_thinking", Data: "Redacted"},
+			}},
+		},
+		"multiple content blocks": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": "Let me look up "}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "the weather for "}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta": "text": "you."}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "content_block_start", "index": 1, "content_block": {"type": "thinking", "thinking": ""}}`,
+				`{"type": "content_block_delta", "index": 1, "delta": {"type": "thinking_delta", "thinking": "I can look this "}}`,
+				`{"type": "content_block_delta", "index": 1, "delta": {"type": "thinking_delta", "thinking": "up using a tool."}}`,
+				`{"type": "content_block_stop", "index": 1}`,
+				`{"type": "content_block_start", "index": 2, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "get_weather", "input": {}}}`,
+				`{"type": "content_block_delta", "index": 2, "delta": {"type": "input_json_delta", "partial_json": "{\"city\": "}}`,
+				`{"type": "content_block_delta", "index": 2, "delta": {"type": "input_json_delta", "partial_json": "\"Los Angeles\"}"}}`,
+				`{"type": "content_block_stop", "index": 2}`,
+				`{"type": "content_block_start", "index": 3, "content_block": {"type": "text", "text": ""}}`,
+				`{"type": "content_block_delta", "index": 3, "delta": {"type": "text_delta", "text": "The weather in Los Angeles"}}`,
+				`{"type": "content_block_delta", "index": 3, "delta": {"type": "text_delta", "text": " is 85 degrees Fahrenheit!"}}`,
+				`{"type": "content_block_stop", "index": 3"}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "text", Text: "Let me look up the weather for you."},
+				{Type: "thinking", Thinking: "I can look this up using a tool."},
+				{Type: "tool_use", ID: "toolu_id", Name: "get_weather", Input: []byte(`{"city": "Los Angeles"}`)},
+				{Type: "text", Text: "The weather in Los Angeles is 85 degrees Fahrenheit!"},
+			}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			message := anthropic.Message{}
+			for _, eventStr := range testCase.events {
+				event := anthropic.MessageStreamEventUnion{}
+				err := (&event).UnmarshalJSON([]byte(eventStr))
+				if err != nil {
+					t.Fatal(err)
+				}
+				(&message).Accumulate(event)
+			}
+			marshaledMessage, err := json.Marshal(message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			marshaledExpectedMessage, err := json.Marshal(testCase.expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(marshaledMessage) != string(marshaledExpectedMessage) {
+				t.Fatalf("Mismatched message: expected %s but got %s", marshaledExpectedMessage, marshaledMessage)
+			}
+		})
 	}
 }

--- a/message_test.go
+++ b/message_test.go
@@ -169,7 +169,6 @@ func TestAccumulate(t *testing.T) {
 		events   []string
 	}{
 		"empty message": {
-			startingMessage: anthropic.Message{},
 			expected:        anthropic.Message{Usage: anthropic.Usage{}},
 			events: []string{
 				`{"type": "message_start", "message": {}}`,


### PR DESCRIPTION
`Accumulate()` previously would return an error when parsing a `tool_use` block that received one or more empty `partial_json` updates. Additionally this PR accumulates `CitationDelta`.

Add test for `Accumulate()`.