### PR TITLE
docs: Fix message creation in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,9 @@ func main() {
 	)
 	message, err := client.Messages.New(context.TODO(), anthropic.MessageNewParams{
 		MaxTokens: 1024,
-		Messages: []anthropic.MessageParam{{
-			Content: []anthropic.ContentBlockParamUnion{{
-				OfRequestTextBlock: &anthropic.TextBlockParam{Text: "What is a quaternion?"},
-			}},
-			Role: anthropic.MessageParamRoleUser,
-		}},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("What is a quaternion?")),
+		},
 		Model: anthropic.ModelClaude3_7SonnetLatest,
 	})
 	if err != nil {


### PR DESCRIPTION
Hey folks, I started a new go mod and copied and pasted the first example from the README.md and it didn't work. Here's the changes I made to create a simple example. 

Use NewUserMessage and NewTextBlock helper functions for cleaner code.

🤖 Generated with [Claude Code](https://claude.ai/code)