### PR TITLE
fix anthropic beta parameter of Bedrock not work

### DIFF
--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -202,6 +202,11 @@ func bedrockMiddleware(signer *v4.Signer, cfg aws.Config) option.Middleware {
 				body, _ = sjson.SetBytes(body, "anthropic_version", DefaultVersion)
 			}
 
+			betas := r.Header.Values("anthropic-beta")
+			if len(betas) > 0 {
+				body, _ = sjson.SetBytes(body, "anthropic_beta", betas)
+			}
+
 			if r.Method == http.MethodPost && DefaultEndpoints[r.URL.Path] {
 				model := gjson.GetBytes(body, "model").String()
 				stream := gjson.GetBytes(body, "stream").Bool()


### PR DESCRIPTION
fix:bedrock using anthropic beta parameter by using 'anthropic_beta' field of http body instead of 'anthropic-beta' parameter of http header

Please see AWS document:  [https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html](url)

Just add the following code into the 'bedrockMiddleware ' function

> 			betas := r.Header.Values("anthropic-beta")
> 			if len(betas) > 0 {
> 				body, _ = sjson.SetBytes(body, "anthropic_beta", betas)
> 			}