### PR TITLE
Fix JSON marshaling for custom content citations

### DIFF
--- a/betamessage.go
+++ b/betamessage.go
@@ -1378,7 +1378,7 @@ func NewBetaTextBlock(text string) BetaContentBlockParamUnion {
 }
 
 func NewBetaImageBlock[
-T BetaBase64ImageSourceParam | BetaURLImageSourceParam | BetaFileImageSourceParam,
+	T BetaBase64ImageSourceParam | BetaURLImageSourceParam | BetaFileImageSourceParam,
 ](source T) BetaContentBlockParamUnion {
 	var image BetaImageBlockParam
 	switch v := any(source).(type) {
@@ -1393,7 +1393,7 @@ T BetaBase64ImageSourceParam | BetaURLImageSourceParam | BetaFileImageSourcePara
 }
 
 func NewBetaDocumentBlock[
-T BetaBase64PDFSourceParam | BetaPlainTextSourceParam | BetaContentBlockSourceParam | BetaURLPDFSourceParam | BetaFileDocumentSourceParam,
+	T BetaBase64PDFSourceParam | BetaPlainTextSourceParam | BetaContentBlockSourceParam | BetaURLPDFSourceParam | BetaFileDocumentSourceParam,
 ](source T) BetaContentBlockParamUnion {
 	var document BetaRequestDocumentBlockParam
 	switch v := any(source).(type) {
@@ -1455,7 +1455,7 @@ func NewBetaServerToolUseBlock(id string, input any, name BetaServerToolUseBlock
 }
 
 func NewBetaWebSearchToolResultBlock[
-T []BetaWebSearchResultBlockParam | BetaWebSearchToolRequestErrorParam,
+	T []BetaWebSearchResultBlockParam | BetaWebSearchToolRequestErrorParam,
 ](content T, toolUseID string) BetaContentBlockParamUnion {
 	var webSearchToolResult BetaWebSearchToolResultBlockParam
 	switch v := any(content).(type) {
@@ -1469,7 +1469,7 @@ T []BetaWebSearchResultBlockParam | BetaWebSearchToolRequestErrorParam,
 }
 
 func NewBetaCodeExecutionToolResultBlock[
-T BetaCodeExecutionToolResultErrorParam | BetaCodeExecutionResultBlockParam,
+	T BetaCodeExecutionToolResultErrorParam | BetaCodeExecutionResultBlockParam,
 ](content T, toolUseID string) BetaContentBlockParamUnion {
 	var codeExecutionToolResult BetaCodeExecutionToolResultBlockParam
 	switch v := any(content).(type) {

--- a/betamessage_test.go
+++ b/betamessage_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -484,5 +485,225 @@ func TestCustomContentWithWorkaround(t *testing.T) {
 		t.Errorf("Expected content to be an array, got %T", result["content"])
 	} else {
 		t.Logf("Workaround produces correct structure with %d elements", len(content))
+	}
+}
+
+// TestBetaContentBlockSourceContentUnionParamMarshalJSON tests the custom MarshalJSON implementation
+// that converts string arrays to proper text block JSON structure for citations
+func TestBetaContentBlockSourceContentUnionParamMarshalJSON(t *testing.T) {
+	t.Run("string array to text blocks conversion", func(t *testing.T) {
+		// Create content chunks as strings
+		chunks := []string{
+			"First document chunk",
+			"Second document chunk", 
+			"Third document chunk",
+		}
+
+		// Create content blocks using the union type
+		contentChunks := make([]anthropic.BetaContentBlockSourceContentUnionParam, len(chunks))
+		for i, chunk := range chunks {
+			contentChunks[i] = anthropic.BetaContentBlockSourceContentUnionParam{
+				OfString: param.NewOpt(chunk),
+			}
+		}
+
+		// Create the content union with string blocks
+		contentUnion := anthropic.BetaContentBlockSourceContentUnionParam{
+			OfBetaContentBlockSourceContent: contentChunks,
+		}
+
+		// Marshal the content union
+		data, err := json.Marshal(contentUnion)
+		if err != nil {
+			t.Fatalf("Failed to marshal content union: %v", err)
+		}
+
+		// Parse the JSON to verify structure
+		var result []interface{}
+		if err := json.Unmarshal(data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal result: %v", err)
+		}
+
+		// Verify we have the expected number of elements
+		if len(result) != len(chunks) {
+			t.Errorf("Expected %d content blocks, got %d", len(chunks), len(result))
+		}
+
+		// Verify each element has the correct structure
+		for i, item := range result {
+			block, ok := item.(map[string]interface{})
+			if !ok {
+				t.Errorf("Expected content[%d] to be an object, got %T", i, item)
+				continue
+			}
+
+			// Check for "type": "text"
+			if blockType, exists := block["type"]; !exists || blockType != "text" {
+				t.Errorf("Expected content[%d].type to be 'text', got %v", i, blockType)
+			}
+
+			// Check for "text" field with correct value
+			if text, exists := block["text"]; !exists {
+				t.Errorf("Expected content[%d] to have 'text' field", i)
+			} else if text != chunks[i] {
+				t.Errorf("Expected content[%d].text to be '%s', got '%v'", i, chunks[i], text)
+			}
+		}
+
+		t.Logf("Successfully converted string array to text blocks: %s", string(data))
+	})
+
+	t.Run("mixed content types should not convert", func(t *testing.T) {
+		// Create mixed content (not all strings)
+		contentChunks := []anthropic.BetaContentBlockSourceContentUnionParam{
+			{OfString: param.NewOpt("First chunk")},
+			{}, // Empty union (not a string)
+		}
+
+		contentUnion := anthropic.BetaContentBlockSourceContentUnionParam{
+			OfBetaContentBlockSourceContent: contentChunks,
+		}
+
+		// Marshal should fall back to default behavior
+		data, err := json.Marshal(contentUnion)
+		if err != nil {
+			t.Fatalf("Failed to marshal mixed content: %v", err)
+		}
+
+		// This should marshal as the default union structure, not as text blocks
+		t.Logf("Mixed content marshaled as: %s", string(data))
+	})
+
+	t.Run("integration with BetaContentBlockSourceParam", func(t *testing.T) {
+		// Test the full integration with BetaContentBlockSourceParam
+		chunks := []string{
+			"Document content part 1",
+			"Document content part 2",
+		}
+
+		contentChunks := make([]anthropic.BetaContentBlockSourceContentUnionParam, len(chunks))
+		for i, chunk := range chunks {
+			contentChunks[i] = anthropic.BetaContentBlockSourceContentUnionParam{
+				OfString: param.NewOpt(chunk),
+			}
+		}
+
+		source := anthropic.BetaContentBlockSourceParam{
+			Type: "content",
+			Content: anthropic.BetaContentBlockSourceContentUnionParam{
+				OfBetaContentBlockSourceContent: contentChunks,
+			},
+		}
+
+		data, err := json.Marshal(source)
+		if err != nil {
+			t.Fatalf("Failed to marshal source: %v", err)
+		}
+
+		// Verify the complete structure
+		var result map[string]interface{}
+		if err := json.Unmarshal(data, &result); err != nil {
+			t.Fatalf("Failed to unmarshal result: %v", err)
+		}
+
+		// Check type field
+		if sourceType, exists := result["type"]; !exists || sourceType != "content" {
+			t.Errorf("Expected type to be 'content', got %v", sourceType)
+		}
+
+		// Check content field structure
+		content, ok := result["content"].([]interface{})
+		if !ok {
+			t.Errorf("Expected content to be an array, got %T", result["content"])
+		} else if len(content) != len(chunks) {
+			t.Errorf("Expected %d content blocks, got %d", len(chunks), len(content))
+		}
+
+		t.Logf("Full source structure marshaled correctly: %s", string(data))
+	})
+}
+
+// TestBetaMessageWithCustomContentCitationsIntegration is a full integration test that verifies
+// the custom MarshalJSON implementation works correctly when sending actual API requests
+func TestBetaMessageWithCustomContentCitationsIntegration(t *testing.T) {
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := anthropic.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("my-anthropic-api-key"),
+	)
+
+	// Create content chunks for document citation
+	chunks := []string{
+		"The Earth orbits the Sun at an average distance of 93 million miles.",
+		"This distance is also known as an Astronomical Unit (AU).",
+		"The orbit takes approximately 365.25 days to complete.",
+	}
+
+	// Build the content blocks using the union type
+	contentChunks := make([]anthropic.BetaContentBlockSourceContentUnionParam, len(chunks))
+	for i, chunk := range chunks {
+		contentChunks[i] = anthropic.BetaContentBlockSourceContentUnionParam{
+			OfString: param.NewOpt(chunk),
+		}
+	}
+
+	// Create a document block with custom content source
+	documentSource := anthropic.BetaContentBlockSourceParam{
+		Type: "content",
+		Content: anthropic.BetaContentBlockSourceContentUnionParam{
+			OfBetaContentBlockSourceContent: contentChunks,
+		},
+	}
+
+	documentBlock := anthropic.NewBetaDocumentBlock(documentSource)
+
+	// Create a message with the document block and citations
+	_, err := client.Beta.Messages.New(context.TODO(), anthropic.BetaMessageNewParams{
+		MaxTokens: 1024,
+		Messages: []anthropic.BetaMessageParam{{
+			Content: []anthropic.BetaContentBlockParamUnion{
+				documentBlock,
+				anthropic.NewBetaTextBlock("Based on the document, how long does Earth's orbit take?"),
+			},
+			Role: anthropic.BetaMessageParamRoleUser,
+		}},
+		Model: anthropic.ModelClaude3_7SonnetLatest,
+		System: []anthropic.BetaTextBlockParam{{
+			Text: "You are a helpful assistant. When answering questions, cite the provided documents using content block citations.",
+			Citations: []anthropic.BetaTextCitationParamUnion{{
+				OfContentBlockLocation: &anthropic.BetaCitationContentBlockLocationParam{
+					CitedText:       "365.25 days",
+					DocumentIndex:   0,
+					DocumentTitle:   anthropic.String("Earth's Orbit Facts"),
+					StartBlockIndex: 2,
+					EndBlockIndex:   2,
+				},
+			}},
+		}},
+	})
+
+	if err != nil {
+		var apierr *anthropic.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+			
+			// Check if the request body contains the properly formatted content blocks
+			requestBody := string(apierr.DumpRequest(false))
+			
+			// Verify the content blocks are formatted as text blocks with type and text fields
+			if !strings.Contains(requestBody, `"type":"text"`) {
+				t.Error("Request body should contain text blocks with 'type':'text'")
+			}
+			if !strings.Contains(requestBody, `"text":"The Earth orbits`) {
+				t.Error("Request body should contain the document content as text blocks")
+			}
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
 	}
 }

--- a/betamessage_test.go
+++ b/betamessage_test.go
@@ -495,7 +495,7 @@ func TestBetaContentBlockSourceContentUnionParamMarshalJSON(t *testing.T) {
 		// Create content chunks as strings
 		chunks := []string{
 			"First document chunk",
-			"Second document chunk", 
+			"Second document chunk",
 			"Third document chunk",
 		}
 
@@ -692,10 +692,10 @@ func TestBetaMessageWithCustomContentCitationsIntegration(t *testing.T) {
 		var apierr *anthropic.Error
 		if errors.As(err, &apierr) {
 			t.Log(string(apierr.DumpRequest(true)))
-			
+
 			// Check if the request body contains the properly formatted content blocks
 			requestBody := string(apierr.DumpRequest(false))
-			
+
 			// Verify the content blocks are formatted as text blocks with type and text fields
 			if !strings.Contains(requestBody, `"type":"text"`) {
 				t.Error("Request body should contain text blocks with 'type':'text'")


### PR DESCRIPTION
**Problem**

When using document blocks with custom content for citations, the SDK was not marshaling the content correctly. The API expects content blocks to be formatted as [{"type": "text", "text": "..."}], but the SDK was sending malformed JSON for string arrays.

**Solution**

Added custom MarshalJSON implementation for BetaContentBlockSourceContentUnionParam that detects when content blocks contain strings and transforms them into the proper text block format expected by the Anthropic API. (I implemented a similar feature in https://github.com/liushuangls/go-anthropic.)

**Testing**

 - Added unit tests to verify the JSON transformation logic
 - Added integration test to confirm the API accepts the properly formatted requests

 This fix enables citations to work correctly with custom document content blocks.
