### PR TITLE
fix: handle invalid JSON in tool use Input field during streaming

### DIFF
--- a/betamessage.go
+++ b/betamessage.go
@@ -3276,6 +3276,13 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
 		}
 		contentBlock := &acc.Content[len(acc.Content)-1]
+
+		if (contentBlock.Type == "tool_use" || contentBlock.Type == "server_tool_use") && len(contentBlock.Input) > 0 {
+			if !json.Valid(contentBlock.Input) {
+				contentBlock.Input = []byte("{}")
+			}
+		}
+
 		cbJson, err := json.Marshal(contentBlock)
 		if err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)

--- a/betamessage_test.go
+++ b/betamessage_test.go
@@ -333,6 +333,18 @@ Therefore, the answer is..."}}`,
 				{Type: "text", Text: "The weather in Los Angeles is 85 degrees Fahrenheit!"},
 			}},
 		},
+		"tool use block with incomplete JSON input": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"command\": \"str_replace\", \"path\": \"some/path/test.go\""}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.BetaMessage{Content: []anthropic.BetaContentBlockUnion{
+				{Type: "tool_use", ID: "toolu_id", Name: "tool_name", Input: []byte("{}")},
+			}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			message := anthropic.BetaMessage{}

--- a/message.go
+++ b/message.go
@@ -2495,6 +2495,13 @@ func (acc *Message) Accumulate(event MessageStreamEventUnion) error {
 			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
 		}
 		contentBlock := &acc.Content[len(acc.Content)-1]
+
+		if (contentBlock.Type == "tool_use" || contentBlock.Type == "server_tool_use") && len(contentBlock.Input) > 0 {
+			if !json.Valid(contentBlock.Input) {
+				contentBlock.Input = []byte("{}")
+			}
+		}
+
 		cbJson, err := json.Marshal(contentBlock)
 		if err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)

--- a/message_test.go
+++ b/message_test.go
@@ -308,6 +308,18 @@ Therefore, the answer is..."}}`,
 				{Type: "text", Text: "The weather in Los Angeles is 85 degrees Fahrenheit!"},
 			}},
 		},
+		"tool use block with incomplete JSON input": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"command\": \"str_replace\", \"path\": \"some/path/test.go\""}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.Message{Content: []anthropic.ContentBlockUnion{
+				{Type: "tool_use", ID: "toolu_id", Name: "tool_name", Input: []byte("{}")},
+			}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			message := anthropic.Message{}


### PR DESCRIPTION
Validates tool use Input fields during ContentBlockStopEvent and resets invalid JSON to '{}' to prevent marshal errors that cause entire message accumulation to fail.

The issue occurs when streaming sends incomplete JSON in InputJSONDelta events, corrupting the Input field and causing 'unexpected end of JSON input' errors during message_stop processing.

Resolves #164