### PR TITLE
fix(vertex): do not override custom http client when using vertex

### DIFF
--- a/vertex/vertex.go
+++ b/vertex/vertex.go
@@ -91,7 +91,8 @@ func vertexMiddleware(region, projectID string) sdkoption.Middleware {
 				body, _ = sjson.SetBytes(body, "anthropic_version", DefaultVersion)
 			}
 
-			if r.URL.Path == "/v1/messages" && r.Method == http.MethodPost {
+			switch {
+			case r.URL.Path == "/v1/messages" && r.Method == http.MethodPost:
 				if projectID == "" {
 					return nil, fmt.Errorf("no projectId was given and it could not be resolved from credentials")
 				}
@@ -107,14 +108,16 @@ func vertexMiddleware(region, projectID string) sdkoption.Middleware {
 				}
 
 				r.URL.Path = fmt.Sprintf("/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:%s", projectID, region, model, specifier)
-			}
 
-			if r.URL.Path == "/v1/messages/count_tokens" && r.Method == http.MethodPost {
+			case r.URL.Path == "/v1/messages/count_tokens" && r.Method == http.MethodPost:
 				if projectID == "" {
 					return nil, fmt.Errorf("no projectId was given and it could not be resolved from credentials")
 				}
 
 				r.URL.Path = fmt.Sprintf("/v1/projects/%s/locations/%s/publishers/anthropic/models/count-tokens:rawPredict", projectID, region)
+
+			default:
+				return nil, fmt.Errorf("vertex middleware does not support %s %s", r.Method, r.URL.Path)
 			}
 
 			reader := bytes.NewReader(body)

--- a/vertex/vertex.go
+++ b/vertex/vertex.go
@@ -68,7 +68,9 @@ func vertexMiddleware(region, projectID string) sdkoption.Middleware {
 			if err != nil {
 				return nil, err
 			}
-			r.Body.Close()
+			if err := r.Body.Close(); err != nil {
+				return nil, err
+			}
 
 			if !gjson.GetBytes(body, "anthropic_version").Exists() {
 				body, _ = sjson.SetBytes(body, "anthropic_version", DefaultVersion)


### PR DESCRIPTION
We've been using the [`go-vcr`](https://github.com/dnaeon/go-vcr) library to handle HTTP requests inside tests, and it gives you a custom HTTP transport, but the SDK _also_ sets one. This PR combine both transports so they work together!