### PR TITLE
feat(bedrock): add bearer token authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,28 @@ func main() {
 
 If you already have an `aws.Config`, you can also use it directly with `bedrock.WithConfig(cfg)`.
 
-Read more about Anthropic and Amazon Bedrock [here](https://docs.anthropic.com/en/api/claude-on-amazon-bedrock).
+### Bearer Token Authentication
+
+You can also authenticate with Bedrock using bearer tokens instead of AWS credentials. This is particularly useful in corporate environments where teams need access to Bedrock without managing AWS credentials, IAM roles, or account-level permissions.
+
+```go
+package main
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/bedrock"
+)
+
+func main() {
+	client := anthropic.NewClient(
+		bedrock.WithBearerToken("your-bearer-token", "us-east-1"),
+	)
+}
+```
+
+The bearer token can be provided directly or via the `AWS_BEARER_TOKEN_BEDROCK` environment variable. If the token parameter is empty, it will automatically read from the environment variable.
+
+Read more about Anthropic and Amazon Bedrock [here](https://docs.anthropic.com/en/api/claude-on-amazon-bedrock) and about Bedrock API keys [here](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html).
 
 ## Google Vertex AI
 

--- a/bedrock/bedrock_test.go
+++ b/bedrock/bedrock_test.go
@@ -71,10 +71,10 @@ func TestBedrockURLEncoding(t *testing.T) {
 			}
 
 			signer := v4.NewSigner()
-			middleware := bedrockMiddleware(signer, cfg)
+			middleware := bedrockMiddleware(signer, cfg, "")
 
 			// Create request body
-			requestBody := map[string]interface{}{
+			requestBody := map[string]any{
 				"model":  tc.model,
 				"stream": tc.stream,
 				"messages": []map[string]string{
@@ -123,5 +123,51 @@ func TestBedrockURLEncoding(t *testing.T) {
 				t.Fatalf("Middleware failed: %v", err)
 			}
 		})
+	}
+}
+
+func TestBedrockBearerToken(t *testing.T) {
+	token := "test-bearer-token"
+	region := "us-west-2"
+
+	middleware := bedrockMiddleware(nil, aws.Config{Region: region}, token)
+
+	requestBody := map[string]any{
+		"model": "claude-3-sonnet",
+		"messages": []map[string]string{
+			{"role": "user", "content": "Hello"},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal request body: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://bedrock-runtime.us-west-2.amazonaws.com/v1/messages", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = middleware(req, func(r *http.Request) (*http.Response, error) {
+		authHeader := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + token
+		if authHeader != expectedAuth {
+			t.Errorf("Expected Authorization header %q, got %q", expectedAuth, authHeader)
+		}
+
+		if r.Header.Get("X-Amz-Date") != "" {
+			t.Error("Expected no AWS SigV4 headers when using bearer token")
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Middleware failed: %v", err)
 	}
 }

--- a/examples/bedrock-bearer-token-streaming/main.go
+++ b/examples/bedrock-bearer-token-streaming/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/bedrock"
+)
+
+func main() {
+	token := os.Getenv("AWS_BEARER_TOKEN_BEDROCK")
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	client := anthropic.NewClient(
+		bedrock.WithBearerToken(token, region),
+	)
+
+	content := "Write a haiku about Go programming."
+
+	println("[user]: " + content)
+
+	stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(content)),
+		},
+		Model: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+	})
+
+	print("[assistant]: ")
+
+	for stream.Next() {
+		event := stream.Current()
+
+		switch eventVariant := event.AsAny().(type) {
+		case anthropic.MessageDeltaEvent:
+			print(eventVariant.Delta.StopSequence)
+		case anthropic.ContentBlockDeltaEvent:
+			switch deltaVariant := eventVariant.Delta.AsAny().(type) {
+			case anthropic.TextDelta:
+				print(deltaVariant.Text)
+			}
+		}
+	}
+
+	println()
+
+	if stream.Err() != nil {
+		println("Stream error:", stream.Err().Error())
+	}
+}

--- a/examples/bedrock-bearer-token/main.go
+++ b/examples/bedrock-bearer-token/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/bedrock"
+)
+
+func main() {
+	token := os.Getenv("AWS_BEARER_TOKEN_BEDROCK")
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	client := anthropic.NewClient(
+		bedrock.WithBearerToken(token, region),
+	)
+
+	content := "Write me a function to call the Anthropic message API in Node.js using the Anthropic Typescript SDK."
+
+	println("[user]: " + content)
+
+	message, err := client.Messages.New(context.TODO(), anthropic.MessageNewParams{
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(content)),
+		},
+		Model:         "us.anthropic.claude-sonnet-4-20250514-v1:0",
+		StopSequences: []string{"```\n"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	println("[assistant]: " + message.Content[0].Text + message.StopSequence)
+}


### PR DESCRIPTION
Adds `WithBearerToken(token, region)` function to enable API key-based authentication with AWS Bedrock as an alternative to AWS credential-based authentication. This streamlines Bedrock access in corporate environments where teams need to use Claude without managing AWS credentials, IAM roles, or account-level permissions.

Bearer tokens can be provided directly or via the `AWS_BEARER_TOKEN_BEDROCK` environment variable. When a bearer token is present, the middleware bypasses AWS SigV4 signing and uses standard `Authorization: Bearer` headers instead.

Includes comprehensive tests and example programs demonstrating both streaming and non-streaming usage with bearer tokens.

References:
- https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html
- https://aws.amazon.com/blogs/machine-learning/accelerate-ai-development-with-amazon-bedrock-api-keys/
- https://github.com/aws/aws-sdk-go-v2/pull/3159

💖 Generated with Crush