### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ Calling `.Messages.NewStreaming()` or [setting a custom timeout](#timeouts) disa
 Request parameters that correspond to file uploads in multipart requests are typed as
 `io.Reader`. The contents of the `io.Reader` will by default be sent as a multipart form
 part with the file name of "anonymous_file" and content-type of "application/octet-stream", so we
-recommend always specifyig a custom content-type with the `anthropic.File(reader io.Reader, filename string, contentType string)`
+recommend always specifying a custom content-type with the `anthropic.File(reader io.Reader, filename string, contentType string)`
 helper we provide to easily wrap any `io.Reader` with the appropriate file name and content type.
 
 ```go

--- a/examples/tools-streaming-jsonschema/main.go
+++ b/examples/tools-streaming-jsonschema/main.go
@@ -160,7 +160,7 @@ type GetTemperatureUnitInput struct {
 var GetTemperatureUnitInputSchema = GenerateSchema[GetTemperatureUnitInput]()
 
 func GetTemperatureUnit(country string) string {
-	return "farenheit"
+	return "fahrenheit"
 }
 
 // Get Weather
@@ -180,7 +180,7 @@ type GetWeatherResponse struct {
 
 func GetWeather(lat, long float64, unit string) GetWeatherResponse {
 	return GetWeatherResponse{
-		Unit:        "farenheit",
+		Unit:        "fahrenheit",
 		Temperature: 122,
 	}
 }

--- a/examples/tools-streaming/main.go
+++ b/examples/tools-streaming/main.go
@@ -50,7 +50,7 @@ func main() {
 				Properties: map[string]interface{}{
 					"lat": map[string]interface{}{
 						"type":        "number",
-						"description": "The lattitude of the location to check weather.",
+						"description": "The latitude of the location to check weather.",
 					},
 					"long": map[string]interface{}{
 						"type":        "number",
@@ -181,7 +181,7 @@ func GetCoordinates(location string) CoordinateResponse {
 }
 
 func GetTemperatureUnit(country string) string {
-	return "farenheit"
+	return "fahrenheit"
 }
 
 type WeatherResponse struct {
@@ -191,7 +191,7 @@ type WeatherResponse struct {
 
 func GetWeather(lat, long float64, unit string) WeatherResponse {
 	return WeatherResponse{
-		Unit:        "farenheit",
+		Unit:        "fahrenheit",
 		Temperature: 122,
 	}
 }

--- a/examples/tools/main.go
+++ b/examples/tools/main.go
@@ -50,7 +50,7 @@ func main() {
 				Properties: map[string]interface{}{
 					"lat": map[string]interface{}{
 						"type":        "number",
-						"description": "The lattitude of the location to check weather.",
+						"description": "The latitude of the location to check weather.",
 					},
 					"long": map[string]interface{}{
 						"type":        "number",
@@ -172,7 +172,7 @@ func GetCoordinates(location string) CoordinateResponse {
 }
 
 func GetTemperatureUnit(country string) string {
-	return "farenheit"
+	return "fahrenheit"
 }
 
 type WeatherResponse struct {
@@ -182,7 +182,7 @@ type WeatherResponse struct {
 
 func GetWeather(lat, long float64, unit string) WeatherResponse {
 	return WeatherResponse{
-		Unit:        "farenheit",
+		Unit:        "fahrenheit",
 		Temperature: 122,
 	}
 }


### PR DESCRIPTION
## Summary
- Fix "specifyig" → "specifying" typo in README.md
- Fix "lattitude" → "latitude" typo in examples
- Fix "farenheit" → "fahrenheit" typo in examples

## Files Changed
- README.md
- examples/tools/main.go
- examples/tools-streaming/main.go
- examples/tools-streaming-jsonschema/main.go