### PR TITLE
feat: add Snowflake Cortex support (similar to Bedrock/Vertex)

### DIFF
--- a/examples/snowflake-streaming/main.go
+++ b/examples/snowflake-streaming/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/snowflake"
+)
+
+func main() {
+	// Set the SNOWFLAKE_AUTH_TOKEN environment variable, or pass the token directly.
+	client := anthropic.NewClient(
+		snowflake.WithAccount("your-account", ""),
+	)
+
+	content := "Write me a haiku about snow."
+
+	println("[user]: " + content)
+
+	stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(content)),
+		},
+		Model: "claude-3-5-sonnet",
+	})
+
+	print("[assistant]: ")
+
+	for stream.Next() {
+		event := stream.Current()
+
+		switch eventVariant := event.AsAny().(type) {
+		case anthropic.MessageDeltaEvent:
+			print(eventVariant.Delta.StopSequence)
+		case anthropic.ContentBlockDeltaEvent:
+			switch deltaVariant := eventVariant.Delta.AsAny().(type) {
+			case anthropic.TextDelta:
+				print(deltaVariant.Text)
+			}
+		}
+	}
+
+	println()
+
+	if stream.Err() != nil {
+		panic(stream.Err())
+	}
+}

--- a/examples/snowflake/main.go
+++ b/examples/snowflake/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/snowflake"
+)
+
+func main() {
+	// Set the SNOWFLAKE_AUTH_TOKEN environment variable, or pass the token directly.
+	client := anthropic.NewClient(
+		snowflake.WithAccount("your-account", ""),
+	)
+
+	content := "Write me a function to call the Anthropic message API in Node.js using the Anthropic Typescript SDK."
+
+	println("[user]: " + content)
+
+	message, err := client.Messages.New(context.TODO(), anthropic.MessageNewParams{
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(content)),
+		},
+		Model:         "claude-3-5-sonnet",
+		StopSequences: []string{"```\n"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	println("[assistant]: " + message.Content[0].Text + message.StopSequence)
+}

--- a/snowflake/snowflake.go
+++ b/snowflake/snowflake.go
@@ -1,0 +1,133 @@
+package snowflake
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/anthropics/anthropic-sdk-go/internal/requestconfig"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const DefaultVersion = "snowflake-2025-01-01"
+
+// WithAccount returns a request option that configures the SDK to use Snowflake Cortex
+// with the given account identifier and token. The account identifier is used to construct
+// the base URL (https://<account>.snowflakecomputing.com/) and the token is used for
+// Bearer authentication.
+//
+// If the token is empty, the SNOWFLAKE_AUTH_TOKEN environment variable is used.
+//
+// The account parameter should be in the format described in the Snowflake documentation
+// for account identifiers (e.g. "myorg-myaccount").
+//
+// For more details, see https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api
+func WithAccount(account string, token string) option.RequestOption {
+	if account == "" {
+		panic("snowflake: account must be provided")
+	}
+
+	if token == "" {
+		token = os.Getenv("SNOWFLAKE_AUTH_TOKEN")
+	}
+
+	if token == "" {
+		panic("snowflake: token must be provided or SNOWFLAKE_AUTH_TOKEN environment variable must be set")
+	}
+
+	// Normalize the account: strip any trailing .snowflakecomputing.com if present
+	account = strings.TrimSuffix(account, ".snowflakecomputing.com")
+
+	baseURL := fmt.Sprintf("https://%s.snowflakecomputing.com/", account)
+	middleware := cortexMiddleware(token)
+
+	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		return rc.Apply(
+			option.WithBaseURL(baseURL),
+			option.WithMiddleware(middleware),
+		)
+	})
+}
+
+// WithBaseURL returns a request option that configures the SDK to use Snowflake Cortex
+// with a custom base URL and token. This is useful when you need to specify a full URL
+// directly (e.g., for proxies or custom deployments).
+//
+// If the token is empty, the SNOWFLAKE_AUTH_TOKEN environment variable is used.
+func WithBaseURL(baseURL string, token string) option.RequestOption {
+	if baseURL == "" {
+		panic("snowflake: baseURL must be provided")
+	}
+
+	if token == "" {
+		token = os.Getenv("SNOWFLAKE_AUTH_TOKEN")
+	}
+
+	if token == "" {
+		panic("snowflake: token must be provided or SNOWFLAKE_AUTH_TOKEN environment variable must be set")
+	}
+
+	middleware := cortexMiddleware(token)
+
+	return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+		return rc.Apply(
+			option.WithBaseURL(baseURL),
+			option.WithMiddleware(middleware),
+		)
+	})
+}
+
+// cortexMiddleware returns middleware that transforms Anthropic API requests into
+// Snowflake Cortex REST API format.
+//
+// The middleware:
+//   - Rewrites /v1/messages to /api/v2/cortex/inference:complete
+//   - Rewrites /v1/messages/count_tokens to /api/v2/cortex/inference:complete (count tokens)
+//   - Adds the anthropic_version field to the request body if not present
+//   - Sets the Authorization header with the Bearer token
+//   - Sets required Accept and Content-Type headers
+func cortexMiddleware(token string) option.Middleware {
+	return func(r *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+		if r.Body != nil {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				return nil, err
+			}
+			r.Body.Close()
+
+			if !gjson.GetBytes(body, "anthropic_version").Exists() {
+				body, _ = sjson.SetBytes(body, "anthropic_version", DefaultVersion)
+			}
+
+			if r.URL.Path == "/v1/messages" && r.Method == http.MethodPost {
+				r.URL.Path = "/api/v2/cortex/inference:complete"
+			}
+
+			if r.URL.Path == "/v1/messages/count_tokens" && r.Method == http.MethodPost {
+				r.URL.Path = "/api/v2/cortex/inference:complete"
+			}
+
+			reader := bytes.NewReader(body)
+			r.Body = io.NopCloser(reader)
+			r.GetBody = func() (io.ReadCloser, error) {
+				_, err := reader.Seek(0, 0)
+				return io.NopCloser(reader), err
+			}
+			r.ContentLength = int64(len(body))
+		}
+
+		// Set authentication header
+		r.Header.Set("Authorization", "Bearer "+token)
+
+		// Set required headers for Cortex REST API
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Accept", "application/json, text/event-stream")
+
+		return next(r)
+	}
+}

--- a/snowflake/snowflake_test.go
+++ b/snowflake/snowflake_test.go
@@ -1,0 +1,356 @@
+package snowflake
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestCortexURLRewriting(t *testing.T) {
+	testCases := []struct {
+		name         string
+		path         string
+		method       string
+		expectedPath string
+	}{
+		{
+			name:         "messages endpoint",
+			path:         "/v1/messages",
+			method:       http.MethodPost,
+			expectedPath: "/api/v2/cortex/inference:complete",
+		},
+		{
+			name:         "count tokens endpoint",
+			path:         "/v1/messages/count_tokens",
+			method:       http.MethodPost,
+			expectedPath: "/api/v2/cortex/inference:complete",
+		},
+		{
+			name:         "non-messages endpoint unchanged",
+			path:         "/v1/other",
+			method:       http.MethodPost,
+			expectedPath: "/v1/other",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			middleware := cortexMiddleware("test-token")
+
+			requestBody := map[string]any{
+				"model":  "claude-3-5-sonnet",
+				"stream": false,
+				"messages": []map[string]string{
+					{"role": "user", "content": "Hello"},
+				},
+			}
+
+			bodyBytes, err := json.Marshal(requestBody)
+			if err != nil {
+				t.Fatalf("Failed to marshal request body: %v", err)
+			}
+
+			req, err := http.NewRequest(tc.method, "https://myorg-myaccount.snowflakecomputing.com"+tc.path, bytes.NewReader(bodyBytes))
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			_, err = middleware(req, func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path != tc.expectedPath {
+					t.Errorf("Expected Path %q, got %q", tc.expectedPath, r.URL.Path)
+				}
+
+				return &http.Response{
+					StatusCode: 200,
+					Body:       http.NoBody,
+				}, nil
+			})
+
+			if err != nil {
+				t.Fatalf("Middleware failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestCortexAuthorizationHeader(t *testing.T) {
+	token := "test-jwt-token"
+	middleware := cortexMiddleware(token)
+
+	requestBody := map[string]any{
+		"model": "claude-3-5-sonnet",
+		"messages": []map[string]string{
+			{"role": "user", "content": "Hello"},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal request body: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://myorg-myaccount.snowflakecomputing.com/v1/messages", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = middleware(req, func(r *http.Request) (*http.Response, error) {
+		authHeader := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + token
+		if authHeader != expectedAuth {
+			t.Errorf("Expected Authorization header %q, got %q", expectedAuth, authHeader)
+		}
+
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Expected Content-Type %q, got %q", "application/json", contentType)
+		}
+
+		accept := r.Header.Get("Accept")
+		if accept != "application/json, text/event-stream" {
+			t.Errorf("Expected Accept %q, got %q", "application/json, text/event-stream", accept)
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Middleware failed: %v", err)
+	}
+}
+
+func TestCortexAnthropicVersionInjected(t *testing.T) {
+	middleware := cortexMiddleware("test-token")
+
+	requestBody := map[string]any{
+		"model": "claude-3-5-sonnet",
+		"messages": []map[string]string{
+			{"role": "user", "content": "Hello"},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal request body: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://myorg-myaccount.snowflakecomputing.com/v1/messages", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = middleware(req, func(r *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body: %v", err)
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("Failed to unmarshal body: %v", err)
+		}
+
+		version, ok := parsed["anthropic_version"]
+		if !ok {
+			t.Fatal("Expected anthropic_version to be set in body")
+		}
+		if version != DefaultVersion {
+			t.Errorf("Expected anthropic_version %q, got %q", DefaultVersion, version)
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Middleware failed: %v", err)
+	}
+}
+
+func TestCortexAnthropicVersionNotOverwritten(t *testing.T) {
+	middleware := cortexMiddleware("test-token")
+
+	customVersion := "custom-version-2024-01-01"
+	requestBody := map[string]any{
+		"model":             "claude-3-5-sonnet",
+		"anthropic_version": customVersion,
+		"messages": []map[string]string{
+			{"role": "user", "content": "Hello"},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal request body: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://myorg-myaccount.snowflakecomputing.com/v1/messages", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = middleware(req, func(r *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body: %v", err)
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("Failed to unmarshal body: %v", err)
+		}
+
+		version := parsed["anthropic_version"]
+		if version != customVersion {
+			t.Errorf("Expected anthropic_version %q to not be overwritten, got %q", customVersion, version)
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Middleware failed: %v", err)
+	}
+}
+
+func TestCortexStreamingRequest(t *testing.T) {
+	middleware := cortexMiddleware("test-token")
+
+	requestBody := map[string]any{
+		"model":  "claude-3-5-sonnet",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "Hello"},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal request body: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://myorg-myaccount.snowflakecomputing.com/v1/messages", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = middleware(req, func(r *http.Request) (*http.Response, error) {
+		// Verify the URL is correctly rewritten
+		if r.URL.Path != "/api/v2/cortex/inference:complete" {
+			t.Errorf("Expected path /api/v2/cortex/inference:complete, got %s", r.URL.Path)
+		}
+
+		// Verify the stream field is preserved (Cortex handles streaming via SSE natively)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Failed to read body: %v", err)
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("Failed to unmarshal body: %v", err)
+		}
+
+		stream, ok := parsed["stream"]
+		if !ok {
+			t.Fatal("Expected stream field to be preserved in body")
+		}
+		if stream != true {
+			t.Errorf("Expected stream to be true, got %v", stream)
+		}
+
+		// Verify model is preserved (unlike Bedrock, Cortex keeps model in body)
+		model, ok := parsed["model"]
+		if !ok {
+			t.Fatal("Expected model field to be preserved in body")
+		}
+		if model != "claude-3-5-sonnet" {
+			t.Errorf("Expected model to be claude-3-5-sonnet, got %v", model)
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Middleware failed: %v", err)
+	}
+}
+
+func TestWithAccountPanicsOnEmptyAccount(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for empty account")
+		}
+	}()
+	WithAccount("", "token")
+}
+
+func TestWithAccountPanicsOnEmptyToken(t *testing.T) {
+	// Ensure the env var is not set
+	os.Unsetenv("SNOWFLAKE_AUTH_TOKEN")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for empty token without env var")
+		}
+	}()
+	WithAccount("myaccount", "")
+}
+
+func TestWithAccountUsesEnvVar(t *testing.T) {
+	os.Setenv("SNOWFLAKE_AUTH_TOKEN", "env-token")
+	defer os.Unsetenv("SNOWFLAKE_AUTH_TOKEN")
+
+	// Should not panic when env var is set
+	opt := WithAccount("myaccount", "")
+	if opt == nil {
+		t.Error("Expected a non-nil option")
+	}
+}
+
+func TestWithAccountStripsSuffix(t *testing.T) {
+	// Verify it doesn't panic and works with the suffix
+	opt := WithAccount("myaccount.snowflakecomputing.com", "test-token")
+	if opt == nil {
+		t.Error("Expected a non-nil option")
+	}
+}
+
+func TestWithBaseURLPanicsOnEmptyURL(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for empty base URL")
+		}
+	}()
+	WithBaseURL("", "token")
+}
+
+func TestWithBaseURLPanicsOnEmptyToken(t *testing.T) {
+	os.Unsetenv("SNOWFLAKE_AUTH_TOKEN")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for empty token without env var")
+		}
+	}()
+	WithBaseURL("https://example.com", "")
+}


### PR DESCRIPTION
Add a new snowflake package that enables using the Anthropic Go SDK with Snowflake's Cortex REST API, following the same middleware pattern used by the existing Bedrock and Vertex integrations.

The implementation includes:
- snowflake.WithAccount() for configuring with a Snowflake account ID
- snowflake.WithBaseURL() for custom endpoint configurations
- Middleware that rewrites /v1/messages to /api/v2/cortex/inference:complete
- Bearer token authentication (direct or via SNOWFLAKE_AUTH_TOKEN env var)
- anthropic_version injection into request bodies
- 12 unit tests covering URL rewriting, auth, streaming, and edge cases
- Basic and streaming usage examples

Closes #274