### PR TITLE
fix: register adaptive discriminator for ThinkingConfigAdaptiveParam …

### DIFF
--- a/betamessage.go
+++ b/betamessage.go
@@ -326,6 +326,7 @@ func init() {
 		"type",
 		apijson.Discriminator[BetaThinkingConfigEnabledParam]("enabled"),
 		apijson.Discriminator[BetaThinkingConfigDisabledParam]("disabled"),
+		apijson.Discriminator[BetaThinkingConfigAdaptiveParam]("adaptive"),
 	)
 }
 

--- a/message.go
+++ b/message.go
@@ -2787,6 +2787,7 @@ func init() {
 		"type",
 		apijson.Discriminator[ThinkingConfigEnabledParam]("enabled"),
 		apijson.Discriminator[ThinkingConfigDisabledParam]("disabled"),
+		apijson.Discriminator[ThinkingConfigAdaptiveParam]("adaptive"),
 	)
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -599,3 +599,27 @@ func TestMessageParamArrayContent(t *testing.T) {
 		t.Errorf("Expected second block text 'second block', got '%s'", message.Content[1].OfText.Text)
 	}
 }
+
+func TestThinkingConfigAdaptiveUnmarshalJSON(t *testing.T) {
+	input := `{"messages":[{"role":"user","content":"hello"}],"model":"claude-opus-4-6","thinking":{"type":"adaptive"}}`
+	var msgParam anthropic.MessageNewParams
+	err := msgParam.UnmarshalJSON([]byte(input))
+	if err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if msgParam.Thinking.OfAdaptive == nil {
+		t.Fatal("Expected Thinking.OfAdaptive to be set, got nil")
+	}
+}
+
+func TestBetaThinkingConfigAdaptiveUnmarshalJSON(t *testing.T) {
+	input := `{"messages":[{"role":"user","content":"hello"}],"model":"claude-opus-4-6","thinking":{"type":"adaptive"}}`
+	var msgParam anthropic.BetaMessageNewParams
+	err := msgParam.UnmarshalJSON([]byte(input))
+	if err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if msgParam.Thinking.OfAdaptive == nil {
+		t.Fatal("Expected Thinking.OfAdaptive to be set, got nil")
+	}
+}


### PR DESCRIPTION
…and BetaThinkingConfigAdaptiveParam

Fixes #279. The 'adaptive' discriminator was not registered in the init() blocks for ThinkingConfigParamUnion and BetaThinkingConfigParamUnion, causing JSON with {"type": "adaptive"} to fail to populate the OfAdaptive field during deserialization.

Added unit tests to verify correct deserialization of adaptive thinking config for both non-beta and beta types.