### PR TITLE
fix: correct Windows OS detection typo in getNormalizedOS

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -38,7 +38,7 @@ func getNormalizedOS() string {
 		return "Android"
 	case "darwin":
 		return "MacOS"
-	case "window":
+	case "windows":
 		return "Windows"
 	case "freebsd":
 		return "FreeBSD"


### PR DESCRIPTION
## Summary

- `getNormalizedOS()` in `internal/requestconfig/requestconfig.go` compares against `"window"` instead of `"windows"`, causing Windows users to always hit the default case and report `"Other:windows"` in the `X-Stainless-OS` header instead of `"Windows"`
- `runtime.GOOS` returns `"windows"` (with trailing 's') on Windows — see [Go documentation](https://pkg.go.dev/runtime#GOOS)
- One-character fix: `"window"` -> `"windows"`

## Test plan

- [x] Verify `runtime.GOOS` documentation confirms the value is `"windows"` not `"window"`
- [ ] Run existing tests to confirm no regressions
- [ ] Verify on a Windows machine that `X-Stainless-OS` header now reports `"Windows"` instead of `"Other:windows"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)