### PR TITLE
fix(bedrock): fix unreachable credential validation in WithConfig

### DIFF
--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -198,9 +198,9 @@ func WithConfig(cfg aws.Config) option.RequestOption {
 	if cfg.BearerAuthTokenProvider == nil {
 		if token := os.Getenv("AWS_BEARER_TOKEN_BEDROCK"); token != "" {
 			cfg.BearerAuthTokenProvider = NewStaticBearerTokenProvider(token)
+		} else if cfg.Credentials == nil {
+			credentialErr = fmt.Errorf("expected AWS credentials to be set")
 		}
-	} else if cfg.BearerAuthTokenProvider == nil && cfg.Credentials == nil {
-		credentialErr = fmt.Errorf("expected AWS credentials to be set")
 	}
 
 	signer := v4.NewSigner()


### PR DESCRIPTION
## Summary

- The credential validation error in `bedrock.WithConfig` is unreachable dead code due to a logic error in the if/else-if chain
- The `else if` branch checks `cfg.BearerAuthTokenProvider == nil`, but it can only execute when the outer `if cfg.BearerAuthTokenProvider == nil` was false — meaning `BearerAuthTokenProvider` is NOT nil, making the nested nil check always false
- As a result, users who call `WithConfig` without any credentials (no bearer token, no `AWS_BEARER_TOKEN_BEDROCK` env var, no `cfg.Credentials`) silently proceed instead of getting the intended `"expected AWS credentials to be set"` error, eventually hitting a nil pointer panic during SigV4 signing
- The fix restructures the check so validation runs after both the bearer token provider and env var fallback have been exhausted

**Before (broken):**
```go
if cfg.BearerAuthTokenProvider == nil {
    if token := os.Getenv("AWS_BEARER_TOKEN_BEDROCK"); token != "" {
        cfg.BearerAuthTokenProvider = NewStaticBearerTokenProvider(token)
    }
} else if cfg.BearerAuthTokenProvider == nil && cfg.Credentials == nil {
    // ^^^ UNREACHABLE: else-if only runs when BearerAuthTokenProvider != nil
    credentialErr = fmt.Errorf("expected AWS credentials to be set")
}
```

**After (fixed):**
```go
if cfg.BearerAuthTokenProvider == nil {
    if token := os.Getenv("AWS_BEARER_TOKEN_BEDROCK"); token != "" {
        cfg.BearerAuthTokenProvider = NewStaticBearerTokenProvider(token)
    } else if cfg.Credentials == nil {
        credentialErr = fmt.Errorf("expected AWS credentials to be set")
    }
}
```

## Test plan

- [ ] Verify that calling `bedrock.WithConfig(aws.Config{})` (no credentials set, no env var) now returns the `"expected AWS credentials to be set"` error
- [ ] Verify that setting `AWS_BEARER_TOKEN_BEDROCK` env var still works correctly
- [ ] Verify that passing `cfg.Credentials` still works correctly
- [ ] Verify that passing `cfg.BearerAuthTokenProvider` directly still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)