### PR TITLE
fix(ssestream): handle content-type parameters and case in decoder lookup

### DIFF
--- a/packages/ssestream/ssestream.go
+++ b/packages/ssestream/ssestream.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 )
@@ -25,8 +26,8 @@ func NewDecoder(res *http.Response) Decoder {
 	}
 
 	var decoder Decoder
-	contentType := res.Header.Get("content-type")
-	if t, ok := decoderTypes[contentType]; ok {
+	mediaType, _, _ := mime.ParseMediaType(res.Header.Get("content-type"))
+	if t, ok := decoderTypes[strings.ToLower(mediaType)]; ok {
 		decoder = t(res.Body)
 	} else {
 		scn := bufio.NewScanner(res.Body)


### PR DESCRIPTION
## Summary

- `NewDecoder` performs an exact string match on the raw `Content-Type` header to find a registered decoder, but `RegisterDecoder` lowercases keys — creating a case-sensitivity mismatch
- Neither function strips media type parameters (e.g., `; charset=utf-8`), so a Content-Type of `application/vnd.amazon.eventstream; charset=utf-8` would fail the lookup
- When the Bedrock eventstream decoder is not matched, the binary eventstream response silently falls through to the text/event-stream SSE decoder, causing decode failures or data corruption
- The fix uses `mime.ParseMediaType` (Go stdlib) to properly extract and normalize the media type before decoder lookup, consistent with how `requestconfig.go` already handles Content-Type parsing elsewhere in this SDK

**Before:**
```go
contentType := res.Header.Get("content-type")
if t, ok := decoderTypes[contentType]; ok {  // exact match, no normalization
```

**After:**
```go
mediaType, _, _ := mime.ParseMediaType(res.Header.Get("content-type"))
if t, ok := decoderTypes[strings.ToLower(mediaType)]; ok {  // normalized + lowercased
```

## Test plan

- [ ] Verify Bedrock streaming still works with standard content-type header
- [ ] Verify decoder is correctly matched when server returns content-type with parameters (e.g., `application/vnd.amazon.eventstream; charset=utf-8`)
- [ ] Verify decoder is correctly matched with mixed-case content-type headers
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)).