### PR TITLE
feat(api): register model_context_window_exceeded StopReason

### DIFF
--- a/message.go
+++ b/message.go
@@ -2818,7 +2818,6 @@ func init() {
 	)
 }
 
-
 func init() {
 	apijson.RegisterUnion[ToolResultBlockParamContentUnion](
 		"type",
@@ -3528,7 +3527,6 @@ func (r Message) RawJSON() string { return r.JSON.raw }
 func (r *Message) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
-
 
 func MessageCountTokensToolParamOfTool(inputSchema ToolInputSchemaParam, name string) MessageCountTokensToolUnionParam {
 	var variant ToolParam
@@ -5237,8 +5235,8 @@ const (
 
 // The properties ID, Input, Name, Type are required.
 type ServerToolUseBlockParam struct {
-	ID    string         `json:"id" api:"required"`
-	Input any            `json:"input,omitzero" api:"required"`
+	ID    string `json:"id" api:"required"`
+	Input any    `json:"input,omitzero" api:"required"`
 	// Any of "web_search", "web_fetch", "code_execution", "bash_code_execution",
 	// "text_editor_code_execution", "tool_search_tool_regex", "tool_search_tool_bm25".
 	Name ServerToolUseBlockParamName `json:"name,omitzero" api:"required"`
@@ -5342,12 +5340,13 @@ func (r *SignatureDelta) UnmarshalJSON(data []byte) error {
 type StopReason string
 
 const (
-	StopReasonEndTurn      StopReason = "end_turn"
-	StopReasonMaxTokens    StopReason = "max_tokens"
-	StopReasonStopSequence StopReason = "stop_sequence"
-	StopReasonToolUse      StopReason = "tool_use"
-	StopReasonPauseTurn    StopReason = "pause_turn"
-	StopReasonRefusal      StopReason = "refusal"
+	StopReasonEndTurn                    StopReason = "end_turn"
+	StopReasonMaxTokens                  StopReason = "max_tokens"
+	StopReasonStopSequence               StopReason = "stop_sequence"
+	StopReasonToolUse                    StopReason = "tool_use"
+	StopReasonPauseTurn                  StopReason = "pause_turn"
+	StopReasonRefusal                    StopReason = "refusal"
+	StopReasonModelContextWindowExceeded StopReason = "model_context_window_exceeded"
 )
 
 type TextBlock struct {
@@ -7843,9 +7842,9 @@ type ToolUseBlock struct {
 	// Tool invocation directly from the model.
 	Caller ToolUseBlockCallerUnion `json:"caller" api:"required"`
 	// necessary custom code modification
-	Input json.RawMessage          `json:"input,required"`
-	Name   string                  `json:"name" api:"required"`
-	Type   constant.ToolUse        `json:"type" api:"required"`
+	Input json.RawMessage  `json:"input,required"`
+	Name  string           `json:"name" api:"required"`
+	Type  constant.ToolUse `json:"type" api:"required"`
 	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
 	JSON struct {
 		ID          respjson.Field


### PR DESCRIPTION
## Summary

- Adds `StopReasonModelContextWindowExceeded` constant to the stable `StopReason` enum in `message.go`
- This stop reason already exists in `BetaStopReason` (in `betamessage.go`) and is [documented in the migration guide](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#migration-guide-moving-from-budget_tokens-to-token_budget), but was missing from the stable API's enum

Closes #295