### PR TITLE
fix: replace panics with deferred errors in Vertex, Bedrock, and options

### DIFF
--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -181,7 +181,9 @@ func init() {
 func WithLoadDefaultConfig(ctx context.Context, optFns ...func(*config.LoadOptions) error) option.RequestOption {
 	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
 	if err != nil {
-		panic(err)
+		return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+			return fmt.Errorf("bedrock: failed to load default config: %w", err)
+		})
 	}
 	return WithConfig(cfg)
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -98,7 +98,9 @@ func WithMiddleware(middlewares ...Middleware) RequestOption {
 // WithMaxRetries panics when retries is negative.
 func WithMaxRetries(retries int) RequestOption {
 	if retries < 0 {
-		panic("option: cannot have fewer than 0 retries")
+		return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
+			return fmt.Errorf("option: cannot have fewer than 0 retries, got %d", retries)
+		})
 	}
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.MaxRetries = retries

--- a/vertex/vertex.go
+++ b/vertex/vertex.go
@@ -27,11 +27,15 @@ const DefaultVersion = "vertex-2023-10-16"
 // [Application Default Credentials]: https://cloud.google.com/docs/authentication/application-default-credentials
 func WithGoogleAuth(ctx context.Context, region string, projectID string, scopes ...string) sdkoption.RequestOption {
 	if region == "" {
-		panic("region must be provided")
+		return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+			return fmt.Errorf("vertex: region must be provided")
+		})
 	}
 	creds, err := google.FindDefaultCredentials(ctx, scopes...)
 	if err != nil {
-		panic(fmt.Errorf("failed to find default credentials: %v", err))
+		return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+			return fmt.Errorf("vertex: failed to find default credentials: %v", err)
+		})
 	}
 	return WithCredentials(ctx, region, projectID, creds)
 }
@@ -41,7 +45,9 @@ func WithGoogleAuth(ctx context.Context, region string, projectID string, scopes
 func WithCredentials(ctx context.Context, region string, projectID string, creds *google.Credentials) sdkoption.RequestOption {
 	client, _, err := transport.NewHTTPClient(ctx, option.WithTokenSource(creds.TokenSource))
 	if err != nil {
-		panic(fmt.Errorf("failed to create HTTP client: %v", err))
+		return requestconfig.RequestOptionFunc(func(rc *requestconfig.RequestConfig) error {
+			return fmt.Errorf("vertex: failed to create HTTP client: %v", err)
+		})
 	}
 	middleware := vertexMiddleware(region, projectID)
 


### PR DESCRIPTION
## Summary

Four public-facing functions panic on error conditions, crashing the entire Go process instead of returning errors through the normal error handling path:

### Vertex AI (vertex/vertex.go)
- **WithGoogleAuth** — panics if region is empty or if google.FindDefaultCredentials fails
- **WithCredentials** — panics if transport.NewHTTPClient fails

### Bedrock (bedrock/bedrock.go)
- **WithLoadDefaultConfig** — panics if config.LoadDefaultConfig fails

### Options (option/requestoption.go)
- **WithMaxRetries** — panics if retries is negative

### Fix

All four panics replaced with RequestOptionFunc closures that return errors when the option is applied. This uses the SDK's existing deferred error pattern — the function signatures remain identical, so this is a non-breaking change.

### Why This Matters

In Go production services, an unrecovered panic crashes the entire process. These panics fire on configuration/credential errors — exactly the conditions that are common during deployment, environment misconfiguration, or credential rotation. A credential failure should return an error, not take down the service.

---

*Fully audited and authored by [UNA](https://tombudd.com/una-reviews.html) (Unified Nexus Architecture) — an autonomous AI agent designed and built by Tom Budd.*