### PR TITLE
test(internal): fix integer overflow in tests for 32-bit architectures

### DIFF
--- a/internal/apiform/form_test.go
+++ b/internal/apiform/form_test.go
@@ -187,7 +187,7 @@ false
 --xxx
 Content-Disposition: form-data; name="b"
 
-237628372683
+123456789
 --xxx
 Content-Disposition: form-data; name="c"
 
@@ -218,7 +218,7 @@ Content-Disposition: form-data; name="f.3"
 4
 --xxx--
 `,
-		Primitives{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+		Primitives{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 	},
 	"primitive_struct,brackets": {
 		`--xxx
@@ -250,7 +250,7 @@ false
 --xxx
 Content-Disposition: form-data; name="slices.0.b"
 
-237628372683
+123456789
 --xxx
 Content-Disposition: form-data; name="slices.0.c"
 
@@ -282,7 +282,7 @@ Content-Disposition: form-data; name="slices.0.f.3"
 --xxx--
 `,
 		Slices{
-			Slice: []Primitives{{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}}},
+			Slice: []Primitives{{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}}},
 		},
 	},
 	"primitive_pointer_struct": {
@@ -293,7 +293,7 @@ false
 --xxx
 Content-Disposition: form-data; name="b"
 
-237628372683
+123456789
 --xxx
 Content-Disposition: form-data; name="c"
 
@@ -330,7 +330,7 @@ Content-Disposition: form-data; name="f.4"
 `,
 		PrimitivePointers{
 			A: P(false),
-			B: P(237628372683),
+			B: P(123456789),
 			C: P(uint(654)),
 			D: P(9999.43),
 			E: P(float32(43.76)),

--- a/internal/apijson/json_test.go
+++ b/internal/apijson/json_test.go
@@ -365,22 +365,22 @@ var tests = map[string]struct {
 	"map_interface":                    {`{"a":1,"b":"str","c":false}`, map[string]any{"a": float64(1), "b": "str", "c": false}},
 
 	"primitive_struct": {
-		`{"a":false,"b":237628372683,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4]}`,
-		Primitives{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+		`{"a":false,"b":123456789,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4]}`,
+		Primitives{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 	},
 
 	"slices": {
-		`{"slices":[{"a":false,"b":237628372683,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4]}]}`,
+		`{"slices":[{"a":false,"b":123456789,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4]}]}`,
 		Slices{
-			Slice: []Primitives{{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}}},
+			Slice: []Primitives{{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}}},
 		},
 	},
 
 	"primitive_pointer_struct": {
-		`{"a":false,"b":237628372683,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4,5]}`,
+		`{"a":false,"b":123456789,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4,5]}`,
 		PrimitivePointers{
 			A: P(false),
-			B: P(237628372683),
+			B: P(123456789),
 			C: P(uint(654)),
 			D: P(9999.43),
 			E: P(float32(43.76)),
@@ -562,12 +562,12 @@ var tests = map[string]struct {
 	},
 
 	"inline_coerce": {
-		`{"a":false,"b":237628372683,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4]}`,
+		`{"a":false,"b":123456789,"c":654,"d":9999.43,"e":43.76,"f":[1,2,3,4]}`,
 		Inline{
-			InlineField: Primitives{A: false, B: 237628372683, C: 0x28e, D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+			InlineField: Primitives{A: false, B: 123456789, C: 0x28e, D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 			JSON: InlineJSON{
-				InlineField: Field{raw: "{\"a\":false,\"b\":237628372683,\"c\":654,\"d\":9999.43,\"e\":43.76,\"f\":[1,2,3,4]}", status: 3},
-				raw:         "{\"a\":false,\"b\":237628372683,\"c\":654,\"d\":9999.43,\"e\":43.76,\"f\":[1,2,3,4]}",
+				InlineField: Field{raw: "{\"a\":false,\"b\":123456789,\"c\":654,\"d\":9999.43,\"e\":43.76,\"f\":[1,2,3,4]}", status: 3},
+				raw:         "{\"a\":false,\"b\":123456789,\"c\":654,\"d\":9999.43,\"e\":43.76,\"f\":[1,2,3,4]}",
 			},
 		},
 	},

--- a/internal/apiquery/query_test.go
+++ b/internal/apiquery/query_test.go
@@ -134,17 +134,17 @@ var tests = map[string]struct {
 	settings QuerySettings
 }{
 	"primitives": {
-		"a=false&b=237628372683&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4",
-		Primitives{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+		"a=false&b=123456789&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4",
+		Primitives{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 		QuerySettings{},
 	},
 
 	"slices_brackets": {
-		`mixed[]=1&mixed[]=2.3&mixed[]=hello&slices[][a]=false&slices[][a]=false&slices[][b]=237628372683&slices[][b]=237628372683&slices[][c]=654&slices[][c]=654&slices[][d]=9999.43&slices[][d]=9999.43&slices[][e]=43.7599983215332&slices[][e]=43.7599983215332&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4`,
+		`mixed[]=1&mixed[]=2.3&mixed[]=hello&slices[][a]=false&slices[][a]=false&slices[][b]=123456789&slices[][b]=123456789&slices[][c]=654&slices[][c]=654&slices[][d]=9999.43&slices[][d]=9999.43&slices[][e]=43.7599983215332&slices[][e]=43.7599983215332&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4`,
 		Slices{
 			Slice: []Primitives{
-				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
-				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+				{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+				{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 			},
 			Mixed: []any{1, 2.3, "hello"},
 		},
@@ -160,11 +160,11 @@ var tests = map[string]struct {
 	},
 
 	"slices_repeat": {
-		`mixed=1&mixed=2.3&mixed=hello&slices[a]=false&slices[a]=false&slices[b]=237628372683&slices[b]=237628372683&slices[c]=654&slices[c]=654&slices[d]=9999.43&slices[d]=9999.43&slices[e]=43.7599983215332&slices[e]=43.7599983215332&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4`,
+		`mixed=1&mixed=2.3&mixed=hello&slices[a]=false&slices[a]=false&slices[b]=123456789&slices[b]=123456789&slices[c]=654&slices[c]=654&slices[d]=9999.43&slices[d]=9999.43&slices[e]=43.7599983215332&slices[e]=43.7599983215332&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4`,
 		Slices{
 			Slice: []Primitives{
-				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
-				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+				{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
+				{A: false, B: 123456789, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 			},
 			Mixed: []any{1, 2.3, "hello"},
 		},
@@ -172,10 +172,10 @@ var tests = map[string]struct {
 	},
 
 	"primitive_pointer_struct": {
-		"a=false&b=237628372683&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4,5",
+		"a=false&b=123456789&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4,5",
 		PrimitivePointers{
 			A: P(false),
-			B: P(237628372683),
+			B: P(123456789),
 			C: P(uint(654)),
 			D: P(9999.43),
 			E: P(float32(43.76)),


### PR DESCRIPTION
Resolves #304

### Description
This PR fixes a compilation issue where `anthropic-sdk-go` test suites fail to compile on 32-bit architectures (like Debian `i386` or `arm32`). 

The failure occurs because several parsing tests in the `internal/` packages mock integer struct fields using an untyped constant of `237628372683`. In Go, the `int` type is 32-bit on 32-bit platforms, and `237628372683` exceeds the maximum bounds of a 32-bit signed integer (`2,147,483,647`), causing the compiler to safely panic.

This PR performs a simple substitution, changing the overloaded constant to `123456789` across the test suites. This safely fits within 32 bits and perfectly preserves the structural serialization tests without needing to change standard struct types to `int64`.

### Testing Verification
The fix was validated by compiling targeting `386` natively:

```bash
$ env GOARCH=386 go vet ./internal/...
$ env GOARCH=386 go build ./internal/...
# Passed with 0 overflow warnings or errors