### PR TITLE
fix: set required Type field in BetaManagedAgentsEventParams helpers

### DIFF
--- a/betasessionevent.go
+++ b/betasessionevent.go
@@ -1122,6 +1122,7 @@ func init() {
 func BetaManagedAgentsEventParamsOfUserMessage(content []BetaManagedAgentsUserMessageEventParamsContentUnion) BetaManagedAgentsEventParamsUnion {
 	var userMessage BetaManagedAgentsUserMessageEventParams
 	userMessage.Content = content
+	userMessage.Type = BetaManagedAgentsUserMessageEventParamsTypeUserMessage
 	return BetaManagedAgentsEventParamsUnion{OfUserMessage: &userMessage}
 }
 
@@ -1142,6 +1143,7 @@ func BetaManagedAgentsEventParamsOfUserToolConfirmation(result BetaManagedAgents
 func BetaManagedAgentsEventParamsOfUserCustomToolResult(customToolUseID string) BetaManagedAgentsEventParamsUnion {
 	var userCustomToolResult BetaManagedAgentsUserCustomToolResultEventParams
 	userCustomToolResult.CustomToolUseID = customToolUseID
+	userCustomToolResult.Type = BetaManagedAgentsUserCustomToolResultEventParamsTypeUserCustomToolResult
 	return BetaManagedAgentsEventParamsUnion{OfUserCustomToolResult: &userCustomToolResult}
 }
 

--- a/betasessionevent_helpers_test.go
+++ b/betasessionevent_helpers_test.go
@@ -1,0 +1,59 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+func TestBetaManagedAgentsEventParamsOfUserMessageSetsType(t *testing.T) {
+	union := anthropic.BetaManagedAgentsEventParamsOfUserMessage(
+		[]anthropic.BetaManagedAgentsUserMessageEventParamsContentUnion{{
+			OfText: &anthropic.BetaManagedAgentsTextBlockParam{
+				Text: "hello",
+				Type: anthropic.BetaManagedAgentsTextBlockTypeText,
+			},
+		}},
+	)
+
+	data, err := json.Marshal(union)
+	if err != nil {
+		t.Fatalf("failed to marshal: %s", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal: %s", err)
+	}
+
+	typ, ok := raw["type"]
+	if !ok {
+		t.Fatal("expected 'type' field to be present in marshaled JSON")
+	}
+	if typ != "user.message" {
+		t.Fatalf("expected type 'user.message', got %q", typ)
+	}
+}
+
+func TestBetaManagedAgentsEventParamsOfUserCustomToolResultSetsType(t *testing.T) {
+	union := anthropic.BetaManagedAgentsEventParamsOfUserCustomToolResult("tool_use_123")
+
+	data, err := json.Marshal(union)
+	if err != nil {
+		t.Fatalf("failed to marshal: %s", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal: %s", err)
+	}
+
+	typ, ok := raw["type"]
+	if !ok {
+		t.Fatal("expected 'type' field to be present in marshaled JSON")
+	}
+	if typ != "user.custom_tool_result" {
+		t.Fatalf("expected type 'user.custom_tool_result', got %q", typ)
+	}
+}


### PR DESCRIPTION
## Summary

- `BetaManagedAgentsEventParamsOfUserMessage` and `BetaManagedAgentsEventParamsOfUserCustomToolResult` helper functions omit the required `Type` field, causing `400 Bad Request` when calling `POST /v1/sessions/{id}/events`
- Sets `Type` automatically in both helpers, matching the pattern used by `OfUserInterrupt` and `OfUserToolConfirmation`
- Adds unit tests verifying the `type` field is present in marshaled JSON

Fixes #315

## Test plan

- [x] New unit tests pass: `go test . -run TestBetaManagedAgentsEventParamsOf -v`
- [x] `go build ./...` passes
- [ ] Verify against live API (tested manually before filing #315, workaround confirmed the fix direction)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
