### PR TITLE
docs: clarify that managed agent outcome events are not supported in Go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The Claude SDK for Go provides access to the [Claude API](https://docs.anthropic
 
 Full documentation is available at **[platform.claude.com/docs/en/api/sdks/go](https://platform.claude.com/docs/en/api/sdks/go)**.
 
+> **Note:** Managed agent outcome events (e.g., `user.define_outcome`) are not yet supported in the Go SDK.
+> The Go example in the managed agents documentation currently references types that do not exist in `anthropic-sdk-go`.
+> Please use the Python or TypeScript SDKs for this feature until Go support is added.
+
 ## Installation
 
 <!-- x-release-please-start-version -->

--- a/examples/session-basic/main.go
+++ b/examples/session-basic/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+func main() {
+	client := anthropic.NewClient()
+	ctx := context.TODO()
+
+	// NOTE: Outcome events (user.define_outcome) are not yet supported in the Go SDK.
+
+	// Create an environment
+	environment, err := client.Beta.Environments.New(ctx, anthropic.BetaEnvironmentNewParams{
+		Name: "example-environment",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Create an agent
+	agent, err := client.Beta.Agents.New(ctx, anthropic.BetaAgentNewParams{
+		Name: "example-agent",
+		Model: anthropic.BetaManagedAgentsModelConfigParams{
+			ID: anthropic.BetaManagedAgentsModelClaudeSonnet4_6,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a session
+	session, err := client.Beta.Sessions.New(ctx, anthropic.BetaSessionNewParams{
+		EnvironmentID: environment.ID,
+		Agent: anthropic.BetaSessionNewParamsAgentUnion{
+			OfBetaManagedAgentsAgents: &anthropic.BetaManagedAgentsAgentParams{
+				ID:   agent.ID,
+				Type: anthropic.BetaManagedAgentsAgentParamsTypeAgent,
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Created session:", session.ID)
+}


### PR DESCRIPTION
Summary :-
Adds a clarification note and a compilable Go example to address unsupported
managed agent outcome events in the Go SDK.

Context :- 
The managed agents documentation includes a Go example using
`user.define_outcome` and related types that do not exist in
anthropic-sdk-go, causing confusion and compilation issues.

Changes :- 
1. Add note in README.md clarifying that outcome events are not supported
2. Add a minimal working Go example (`examples/session-basic/main.go`)
3. That uses only supported SDK APIs

Result :- 
1. Prevents confusion around non-existent types
2. Provides a working reference for Go users
3. Ensures example code compiles successfully

Fixes #320