### PR TITLE
fix(encoder): honor default struct tag so JSONOutputFormatParam.Type is never elided

### DIFF
--- a/internal/encoding/json/encode.go
+++ b/internal/encoding/json/encode.go
@@ -770,6 +770,15 @@ FieldLoop:
 			e.WriteString(f.nameNonEsc)
 		}
 		opts.quoted = f.quoted
+		// EDIT(begin): honor `default:"..."` tag for string-kinded fields.
+		// If the field carries a default and its current value is the zero
+		// value, emit the pre-marshaled default literal instead of invoking
+		// the field encoder. See issue #328.
+		if f.hasDefault && fv.IsValid() && fv.IsZero() {
+			e.Buffer.Write(f.defaultJSON)
+			continue
+		}
+		// EDIT(end)
 		f.encoder(e, fv, opts)
 	}
 	if next == '{' {
@@ -1118,6 +1127,16 @@ type field struct {
 	// EDIT(begin): save the timefmt if present
 	timefmt string
 	// EDIT(end)
+
+	// EDIT(begin): save the default value if present
+	// hasDefault is set when the struct field carries a `default:"..."` tag.
+	// When the field's value is the zero value, the encoder emits defaultJSON
+	// (a pre-marshaled JSON literal) instead of running the field's encoder.
+	// This guarantees fields like `constant.*` typed members marshal their
+	// documented default even when callers leave them at zero. See issue #328.
+	hasDefault  bool
+	defaultJSON []byte
+	// EDIT(end)
 }
 
 type isZeroer interface {
@@ -1234,6 +1253,19 @@ func typeFields(t reflect.Type) structFields {
 						timefmt: sf.Tag.Get("format"),
 						// EDIT(end)
 					}
+					// EDIT(begin): record `default:"..."` tag for string-kinded fields.
+					// Mirrors the contract in internal/apijson/encoder.go so request-body
+					// marshaling preserves documented defaults (e.g. `constant.JSONSchema`
+					// always serializes as "json_schema" even when left zero).
+					if ft.Kind() == reflect.String {
+						if raw, ok := sf.Tag.Lookup("default"); ok {
+							if encoded, err := Marshal(raw); err == nil {
+								field.hasDefault = true
+								field.defaultJSON = encoded
+							}
+						}
+					}
+					// EDIT(end)
 					field.nameBytes = []byte(field.name)
 
 					// Build nameEscHTML and nameNonEsc ahead of time.

--- a/messageutil_test.go
+++ b/messageutil_test.go
@@ -1,6 +1,7 @@
 package anthropic_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -51,6 +52,68 @@ func TestContentBlockUnionToParam(t *testing.T) {
 		}
 		if len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem) != 1 {
 			t.Errorf("Expected 1 search result in param, got %d", len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem))
+		}
+	})
+}
+
+// TestJSONOutputFormatParamTypeAlwaysMarshaled is a regression test for issue
+// https://github.com/anthropics/anthropic-sdk-go/issues/328 — the structured-
+// output `type` discriminator was being elided from the request body, which
+// caused the API to hang. The field is documented as elidable (its zero value
+// should marshal as "json_schema") via the `default:"json_schema"` struct tag,
+// so request bodies must always carry it.
+func TestJSONOutputFormatParamTypeAlwaysMarshaled(t *testing.T) {
+	wantType := []byte(`"type":"json_schema"`)
+
+	t.Run("zero Type emits default", func(t *testing.T) {
+		body, err := json.Marshal(anthropic.JSONOutputFormatParam{
+			Schema: map[string]any{"type": "object"},
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !bytes.Contains(body, wantType) {
+			t.Errorf("missing %s in %s", wantType, body)
+		}
+	})
+
+	t.Run("explicit Type round-trips", func(t *testing.T) {
+		body, err := json.Marshal(anthropic.JSONOutputFormatParam{
+			Schema: map[string]any{"type": "object"},
+			Type:   constant.JSONSchema("json_schema"),
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !bytes.Contains(body, wantType) {
+			t.Errorf("missing %s in %s", wantType, body)
+		}
+	})
+
+	t.Run("nested in MessageNewParams", func(t *testing.T) {
+		params := anthropic.MessageNewParams{
+			MaxTokens: 100,
+			Model:     anthropic.ModelClaudeSonnet4_5,
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
+			},
+			OutputConfig: anthropic.OutputConfigParam{
+				Format: anthropic.JSONOutputFormatParam{
+					Schema: map[string]any{"type": "object"},
+				},
+			},
+		}
+		body, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !bytes.Contains(body, wantType) {
+			t.Errorf("missing %s in %s", wantType, body)
+		}
+		// Sanity check: the `type` we found is the one inside output_config.format,
+		// not a stray copy from a nested schema.
+		if !bytes.Contains(body, []byte(`"format":{"schema":`)) {
+			t.Errorf("unexpected body shape: %s", body)
 		}
 	})
 }

--- a/packages/param/encoder_test.go
+++ b/packages/param/encoder_test.go
@@ -551,3 +551,56 @@ func TestAppendCompact(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultStructTag verifies the shimmed JSON encoder honors the
+// `default:"..."` tag on string-kinded fields. Generated SDK types rely on
+// this contract to ensure constant discriminators (e.g. the `type` field on
+// JSONOutputFormatParam) appear in marshaled request bodies even when the
+// caller leaves them at their zero value. Regression for
+// https://github.com/anthropics/anthropic-sdk-go/issues/328.
+func TestDefaultStructTag(t *testing.T) {
+	type defaulted struct {
+		Type string `json:"type" default:"json_schema"`
+	}
+	type named string
+	type namedDefaulted struct {
+		Type named `json:"type" default:"json_schema"`
+	}
+	type noDefault struct {
+		Type string `json:"type"`
+	}
+
+	tests := map[string]struct {
+		value    any
+		expected string
+	}{
+		"zero/plain-string": {
+			defaulted{},
+			`{"type":"json_schema"}`,
+		},
+		"zero/named-string": {
+			namedDefaulted{},
+			`{"type":"json_schema"}`,
+		},
+		"non-zero/preserves-value": {
+			defaulted{Type: "override"},
+			`{"type":"override"}`,
+		},
+		"no-default-tag/zero-stays-empty": {
+			noDefault{},
+			`{"type":""}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, err := shimjson.Marshal(test.value)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(b) != test.expected {
+				t.Fatalf("expected %s, got %s", test.expected, b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #328.

## Problem

`JSONOutputFormatParam` (and the beta variant) declare a constant discriminator that the SDK promises will marshal as `"json_schema"` even at the zero value:

```go
type JSONOutputFormatParam struct {
    Schema map[string]any      `json:"schema,omitzero" api:"required"`
    // This field can be elided, and will marshal its zero value as "json_schema".
    Type   constant.JSONSchema `json:"type" default:"json_schema"`
    paramObj
}
```

The `default:"json_schema"` tag is honored by `internal/apijson/encoder.go` (used for response decoding paths), but `param.MarshalObject` — the path that produces request bodies — calls through to the shimmed `encoding/json` in `internal/encoding/json/`, which never read the tag. When the discriminator was missing, the Anthropic API silently hung the request rather than 400-ing, and the SDK's 10-minute timeout fired with `context deadline exceeded`. The Python SDK is unaffected because it serializes the discriminator explicitly.

## Fix

Teach the shim struct encoder to honor `default:"..."` on string-kinded fields. At field-discovery time we pre-marshal the literal once; at encode time, if the field's value is zero, we write the pre-marshaled literal in place of running the field encoder. Non-zero values bypass the default and round-trip unchanged.

This is the smallest fix consistent with the existing tag contract: nothing in the generated code needs to change, the discriminator continues to be elidable at the call site, and the `default:` tag now means the same thing on both the request and response sides of the SDK.

## Tests

- `TestDefaultStructTag` (`packages/param/encoder_test.go`) — direct encoder-level coverage: zero plain-string, zero named-string, non-zero preserved, no-default-tag still emits empty. Confirmed to fail on `main` and pass with the fix.
- `TestJSONOutputFormatParamTypeAlwaysMarshaled` (`messageutil_test.go`) — end-to-end regression: the three shapes from the issue (`JSONOutputFormatParam` alone with zero `Type`, with explicit `Type`, and nested inside `MessageNewParams`).

## Notes

- Scoped to `reflect.String`-kinded fields; that matches the only kind generated code uses `default:` on today (`constant.*` named string types) and matches `parseDefaultStructTag` in `internal/apijson/tag.go`. Widening later if other kinds need it is mechanical.
- The shim encoder file is forked from the standard library with `EDIT(begin)/EDIT(end)` markers; this change keeps that convention so the diff against upstream stays auditable.
