### PR TITLE
fix(messageutil): preserve zero-valued fields in tool result ToParam (#317, #322)

### DIFF
--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -369,7 +369,7 @@ func (r BetaTextEditorCodeExecutionToolResultBlock) ToParam() BetaTextEditorCode
 			ErrorMessage: paramutil.ToOpt(r.Content.ErrorMessage, r.Content.JSON.ErrorMessage),
 		}
 	} else {
-		p.Content = param.Override[BetaTextEditorCodeExecutionToolResultBlockParamContentUnion](r.Content.RawJSON())
+		p.Content = param.Override[BetaTextEditorCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	}
 	return p
 }
@@ -393,21 +393,10 @@ func (r BetaBashCodeExecutionToolResultBlock) ToParam() BetaBashCodeExecutionToo
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
 
-	if r.Content.JSON.ErrorCode.Valid() {
-		p.Content.OfRequestBashCodeExecutionToolResultError = &BetaBashCodeExecutionToolResultErrorParam{
-			ErrorCode: BetaBashCodeExecutionToolResultErrorParamErrorCode(r.Content.ErrorCode),
-		}
-	} else {
-		requestBashContentResult := &BetaBashCodeExecutionResultBlockParam{
-			ReturnCode: r.Content.ReturnCode,
-			Stderr:     r.Content.Stderr,
-			Stdout:     r.Content.Stdout,
-		}
-		for _, block := range r.Content.Content {
-			requestBashContentResult.Content = append(requestBashContentResult.Content, block.ToParam())
-		}
-		p.Content.OfRequestBashCodeExecutionResultBlock = requestBashContentResult
-	}
+	// Use raw JSON passthrough to preserve fields that would otherwise be
+	// dropped by `omitzero` (e.g. zero ReturnCode, empty Stderr/Stdout, or
+	// empty ErrorCode), which the API requires on the next turn. See #322.
+	p.Content = param.Override[BetaBashCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 
 	return p
 }
@@ -423,20 +412,11 @@ func (r BetaCodeExecutionToolResultBlock) ToParam() BetaCodeExecutionToolResultB
 	var p BetaCodeExecutionToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
-	if r.Content.JSON.ErrorCode.Valid() {
-		p.Content.OfError = &BetaCodeExecutionToolResultErrorParam{
-			ErrorCode: r.Content.ErrorCode,
-		}
-	} else {
-		p.Content.OfResultBlock = &BetaCodeExecutionResultBlockParam{
-			ReturnCode: r.Content.ReturnCode,
-			Stderr:     r.Content.Stderr,
-			Stdout:     r.Content.Stdout,
-		}
-		for _, block := range r.Content.Content {
-			p.Content.OfResultBlock.Content = append(p.Content.OfResultBlock.Content, block.ToParam())
-		}
-	}
+
+	// Use raw JSON passthrough to preserve fields that would otherwise be
+	// dropped by `omitzero` (e.g. zero ReturnCode, empty Stderr/Stdout, or
+	// empty ErrorCode), which the API requires on the next turn. See #322.
+	p.Content = param.Override[BetaCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	return p
 }
 
@@ -451,19 +431,11 @@ func (r BetaToolSearchToolResultBlock) ToParam() BetaToolSearchToolResultBlockPa
 	var p BetaToolSearchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
-	if r.Content.JSON.ErrorCode.Valid() {
-		p.Content.OfRequestToolSearchToolResultError = &BetaToolSearchToolResultErrorParam{
-			ErrorCode: BetaToolSearchToolResultErrorParamErrorCode(r.Content.ErrorCode),
-		}
-	} else {
-		p.Content.OfRequestToolSearchToolSearchResultBlock = &BetaToolSearchToolSearchResultBlockParam{}
-		for _, block := range r.Content.ToolReferences {
-			p.Content.OfRequestToolSearchToolSearchResultBlock.ToolReferences = append(
-				p.Content.OfRequestToolSearchToolSearchResultBlock.ToolReferences,
-				block.ToParam(),
-			)
-		}
-	}
+
+	// Use raw JSON passthrough to preserve the required `error_code` field on
+	// the error variant (the typed field is tagged `omitzero`, so an empty
+	// ErrorCode would be silently dropped). See #317.
+	p.Content = param.Override[BetaToolSearchToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	return p
 }
 

--- a/messageutil.go
+++ b/messageutil.go
@@ -316,21 +316,10 @@ func (r BashCodeExecutionToolResultBlock) ToParam() BashCodeExecutionToolResultB
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
 
-	if r.Content.JSON.ErrorCode.Valid() {
-		p.Content.OfRequestBashCodeExecutionToolResultError = &BashCodeExecutionToolResultErrorParam{
-			ErrorCode: BashCodeExecutionToolResultErrorCode(r.Content.ErrorCode),
-		}
-	} else {
-		requestBashContentResult := &BashCodeExecutionResultBlockParam{
-			ReturnCode: r.Content.ReturnCode,
-			Stderr:     r.Content.Stderr,
-			Stdout:     r.Content.Stdout,
-		}
-		for _, block := range r.Content.Content {
-			requestBashContentResult.Content = append(requestBashContentResult.Content, block.ToParam())
-		}
-		p.Content.OfRequestBashCodeExecutionResultBlock = requestBashContentResult
-	}
+	// Use raw JSON passthrough to preserve fields that would otherwise be
+	// dropped by `omitzero` (e.g. zero ReturnCode, empty Stderr/Stdout, or
+	// empty ErrorCode), which the API requires on the next turn. See #322.
+	p.Content = param.Override[BashCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 
 	return p
 }
@@ -346,20 +335,11 @@ func (r CodeExecutionToolResultBlock) ToParam() CodeExecutionToolResultBlockPara
 	var p CodeExecutionToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
-	if r.Content.JSON.ErrorCode.Valid() {
-		p.Content.OfRequestCodeExecutionToolResultError = &CodeExecutionToolResultErrorParam{
-			ErrorCode: r.Content.ErrorCode,
-		}
-	} else {
-		p.Content.OfRequestCodeExecutionResultBlock = &CodeExecutionResultBlockParam{
-			ReturnCode: r.Content.ReturnCode,
-			Stderr:     r.Content.Stderr,
-			Stdout:     r.Content.Stdout,
-		}
-		for _, block := range r.Content.Content {
-			p.Content.OfRequestCodeExecutionResultBlock.Content = append(p.Content.OfRequestCodeExecutionResultBlock.Content, block.ToParam())
-		}
-	}
+
+	// Use raw JSON passthrough to preserve fields that would otherwise be
+	// dropped by `omitzero` (e.g. zero ReturnCode, empty Stderr/Stdout, or
+	// empty ErrorCode), which the API requires on the next turn. See #322.
+	p.Content = param.Override[CodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	return p
 }
 
@@ -380,7 +360,7 @@ func (r TextEditorCodeExecutionToolResultBlock) ToParam() TextEditorCodeExecutio
 			ErrorMessage: paramutil.ToOpt(r.Content.ErrorMessage, r.Content.JSON.ErrorMessage),
 		}
 	} else {
-		p.Content = param.Override[TextEditorCodeExecutionToolResultBlockParamContentUnion](r.Content.RawJSON())
+		p.Content = param.Override[TextEditorCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	}
 	return p
 }
@@ -389,19 +369,11 @@ func (r ToolSearchToolResultBlock) ToParam() ToolSearchToolResultBlockParam {
 	var p ToolSearchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
-	if r.Content.JSON.ErrorCode.Valid() {
-		p.Content.OfRequestToolSearchToolResultError = &ToolSearchToolResultErrorParam{
-			ErrorCode: ToolSearchToolResultErrorCode(r.Content.ErrorCode),
-		}
-	} else {
-		p.Content.OfRequestToolSearchToolSearchResultBlock = &ToolSearchToolSearchResultBlockParam{}
-		for _, block := range r.Content.ToolReferences {
-			p.Content.OfRequestToolSearchToolSearchResultBlock.ToolReferences = append(
-				p.Content.OfRequestToolSearchToolSearchResultBlock.ToolReferences,
-				block.ToParam(),
-			)
-		}
-	}
+
+	// Use raw JSON passthrough to preserve the required `error_code` field on
+	// the error variant (the typed field is tagged `omitzero`, so an empty
+	// ErrorCode would be silently dropped). See #317.
+	p.Content = param.Override[ToolSearchToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	return p
 }
 

--- a/messageutil_test.go
+++ b/messageutil_test.go
@@ -2,6 +2,7 @@ package anthropic_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -29,6 +30,45 @@ func TestContentBlockUnionToParam(t *testing.T) {
 		}
 		if result.OfText.Type != constant.Text("text") {
 			t.Errorf("Expected type 'text', got '%s'", result.OfText.Type)
+		}
+	})
+
+	t.Run("CodeExecutionToolResultBlock preserves zero-valued stdout/stderr/return_code (regression for #322)", func(t *testing.T) {
+		// A successful code execution where return_code is 0 and stdout/stderr
+		// are empty would previously be marshalled as
+		// {"type":"code_execution_result"} (all fields dropped via omitzero),
+		// which the API rejects on the next turn.
+		raw := `{"type":"code_execution_tool_result","tool_use_id":"srvtoolu_1","content":{"type":"code_execution_result","return_code":0,"stdout":"","stderr":"","content":[]}}`
+		result := unmarshalContentBlockParam(t, raw)
+		if result.OfCodeExecutionToolResult == nil {
+			t.Fatal("Expected OfCodeExecutionToolResult to be non-nil")
+		}
+		marshalled, err := json.Marshal(result.OfCodeExecutionToolResult.Content)
+		if err != nil {
+			t.Fatalf("failed to marshal content: %v", err)
+		}
+		got := string(marshalled)
+		for _, key := range []string{`"return_code"`, `"stdout"`, `"stderr"`} {
+			if !strings.Contains(got, key) {
+				t.Errorf("expected %s to be present in marshalled content (got %s)", key, got)
+			}
+		}
+	})
+
+	t.Run("ToolSearchToolResultBlock preserves empty error_code (regression for #317)", func(t *testing.T) {
+		// An empty error_code on a tool_search_tool_result_error would
+		// previously be dropped, producing {"type":"tool_search_tool_result_error"}.
+		raw := `{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_2","content":{"type":"tool_search_tool_result_error","error_code":""}}`
+		result := unmarshalContentBlockParam(t, raw)
+		if result.OfToolSearchToolResult == nil {
+			t.Fatal("Expected OfToolSearchToolResult to be non-nil")
+		}
+		marshalled, err := json.Marshal(result.OfToolSearchToolResult.Content)
+		if err != nil {
+			t.Fatalf("failed to marshal content: %v", err)
+		}
+		if !strings.Contains(string(marshalled), `"error_code"`) {
+			t.Errorf("expected error_code to be present in marshalled content (got %s)", string(marshalled))
 		}
 	})
 


### PR DESCRIPTION
## Summary

The `ToParam()` methods on `CodeExecutionToolResultBlock`, `BashCodeExecutionToolResultBlock`, `ToolSearchToolResultBlock` and their `Beta` counterparts re-marshal server response blocks through struct fields tagged `json:"...,omitzero"`. Zero-valued but required fields (`return_code: 0`, empty `stdout`/`stderr`, empty `error_code`) are silently dropped, and the next API call returns 400 on the now-malformed content block.

Fixes #317 and #322.

## Root cause

Two stacked bugs in the manual `messageutil.go` / `betamessageutil.go` files (not Stainless-generated):

1. **`omitzero` strips required zero values.** `*ResultBlockParam` fields are tagged `omitzero`, so when `ToParam()` round-trips a server response into params, `return_code: 0`, `stdout: ""`, `stderr: ""`, and `error_code: ""` disappear. The API rejects the resulting block on the next turn.
2. **`param.Override` was given a Go `string` instead of `json.RawMessage`.** In the existing `TextEditorCodeExecutionToolResultBlock.ToParam` (and its beta mirror), `param.Override[T](r.Content.RawJSON())` was passing a `string`, which `param.MarshalUnion` -> `shimjson.Marshal` then encodes as a JSON string literal (double-encoded). The documented usage (`packages/param/param.go`) is `json.RawMessage(...)`.

## Fix

Use raw-JSON passthrough on the union content directly:

```go
return ContentBlockParamOfXxxToolResult(
    param.Override[XxxToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON())),
    r.ToolUseID,
)
```

This forwards the exact server-validated payload unchanged, preserving zero-valued required fields and the variant discriminator without the SDK having to introspect each variant.

Affected functions:
- `messageutil.go`: `BashCodeExecutionToolResultBlock.ToParam`, `CodeExecutionToolResultBlock.ToParam`, `ToolSearchToolResultBlock.ToParam`, and `TextEditorCodeExecutionToolResultBlock.ToParam` (existing call corrected).
- `betamessageutil.go`: `BetaBashCodeExecutionToolResultBlock.ToParam`, `BetaCodeExecutionToolResultBlock.ToParam`, `BetaToolSearchToolResultBlock.ToParam`, `BetaTextEditorCodeExecutionToolResultBlock.ToParam` (existing call corrected).

## Tests

Adds two regression sub-tests in `messageutil_test.go` (`TestContentBlockUnionToParam`):
- preserves zero-valued `stdout` / `stderr` / `return_code` for `code_execution_tool_result` (#322).
- preserves empty `error_code` for `tool_search_tool_result_error` (#317).

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -run TestContentBlockUnionToParam ./...` passes (all sub-tests)
- [ ] Maintainers: confirm Prism-backed integration tests (unrelated, pre-existing failures locally due to no mock server)

## Notes

- Manual files only — no Stainless-generated code touched.
- `WebSearchToolResultBlock.ToParam` (#242) was intentionally left alone: its union shape diverges (top-level slice variant vs. struct variant) and warrants a separate look.

Closes #317.
Closes #322.