### PR TITLE
fix(accumulator): sanitize invalid tool_use Input before marshaling

### DIFF
--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -68,6 +68,11 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 			cb.Content.OfString = delta.Content
 		}
 	case BetaRawMessageStopEvent:
+		// Sanitize invalid Input on any block before re-marshaling — see
+		// sanitizeBetaContentBlockInput for the failure mode this guards against.
+		for i := range acc.Content {
+			sanitizeBetaContentBlockInput(&acc.Content[i])
+		}
 		// Re-marshal the accumulated message to update JSON.raw so that AsAny()
 		// returns the accumulated data rather than the original stream data
 		accJSON, err := json.Marshal(acc)
@@ -82,6 +87,7 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
 		}
 		contentBlock := &acc.Content[len(acc.Content)-1]
+		sanitizeBetaContentBlockInput(contentBlock)
 		cbJSON, err := json.Marshal(contentBlock)
 		if err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)
@@ -90,6 +96,27 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 	}
 
 	return nil
+}
+
+// sanitizeBetaContentBlockInput replaces a non-nil-but-invalid Input json.RawMessage
+// with []byte("{}") so the surrounding json.Marshal in Accumulate doesn't fail
+// the whole stream. Three real-world shapes hit this: an empty non-nil slice
+// (`""` in the start event), a truncated object (`{"argument":` when max_tokens
+// cuts off mid tool_use), and an unclosed string (`{"x": "abc`). All three
+// produce the same `unexpected end of JSON input` error from json.Compact
+// during marshal, even though the rest of the message accumulated fine. Patching
+// to `{}` rather than `null` keeps the tool_use structurally valid, so the
+// caller's tool dispatcher gets a real (if empty) object instead of having to
+// special-case `null`. Nil is left alone — it marshals as `null` cleanly and
+// carries the distinct "field absent" semantic.
+//
+// See https://github.com/anthropics/anthropic-sdk-go/issues/292 — reported as
+// "Streaming: json: error calling MarshalJSON for type json.RawMessage:
+// unexpected end of JSON input" when max_tokens is reached mid tool_use.
+func sanitizeBetaContentBlockInput(cb *BetaContentBlockUnion) {
+	if cb.Input != nil && !json.Valid(cb.Input) {
+		cb.Input = []byte("{}")
+	}
 }
 
 // ParseOutput finds the first text content block in the message and unmarshals it

--- a/betamessageutil_test.go
+++ b/betamessageutil_test.go
@@ -1,0 +1,83 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// TestBetaAccumulateRecoversFromInvalidToolUseInput mirrors
+// TestAccumulateRecoversFromInvalidToolUseInput for the Beta API surface —
+// see that test's comment for the bug we're guarding against
+// (https://github.com/anthropics/anthropic-sdk-go/issues/292).
+func TestBetaAccumulateRecoversFromInvalidToolUseInput(t *testing.T) {
+	for name, partials := range map[string][]string{
+		"empty non-nil":         {""},
+		"truncated":             {`{"argument":`},
+		"unclosed string":       {`{"x": "abc`},
+		"multi-delta truncated": {`{"args`, `ument":`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			events := []string{
+				`{"type": "message_start", "message": {"id": "msg_x", "type": "message", "role": "assistant", "content": [], "model": "test", "usage": {"input_tokens": 0, "output_tokens": 0}}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+			}
+			for _, partial := range partials {
+				events = append(events, fmt.Sprintf(
+					`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": %q}}`,
+					partial,
+				))
+			}
+			events = append(events,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			)
+
+			message := anthropic.BetaMessage{}
+			for _, eventStr := range events {
+				event := anthropic.BetaRawMessageStreamEventUnion{}
+				if err := (&event).UnmarshalJSON([]byte(eventStr)); err != nil {
+					t.Fatalf("unmarshal %s: %v", eventStr, err)
+				}
+				if err := (&message).Accumulate(event); err != nil {
+					t.Fatalf("Accumulate must not error on the malformed-input case; got %v", err)
+				}
+			}
+			if _, err := json.Marshal(message); err != nil {
+				t.Fatalf("json.Marshal must succeed after sanitisation; got %v", err)
+			}
+			if len(message.Content) != 1 {
+				t.Fatalf("expected one content block; got %d", len(message.Content))
+			}
+			if got := string(message.Content[0].Input); got != "{}" {
+				t.Errorf("Input should be sanitised to {}; got %q", got)
+			}
+		})
+	}
+}
+
+func TestBetaAccumulateLeavesValidInputUntouched(t *testing.T) {
+	events := []string{
+		`{"type": "message_start", "message": {"id": "msg_x", "type": "message", "role": "assistant", "content": [], "model": "test", "usage": {"input_tokens": 0, "output_tokens": 0}}}`,
+		`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"argument\":"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": " \"value\"}"}}`,
+		`{"type": "content_block_stop", "index": 0}`,
+		`{"type": "message_stop"}`,
+	}
+	message := anthropic.BetaMessage{}
+	for _, eventStr := range events {
+		event := anthropic.BetaRawMessageStreamEventUnion{}
+		if err := (&event).UnmarshalJSON([]byte(eventStr)); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if err := (&message).Accumulate(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := string(message.Content[0].Input); got != `{"argument": "value"}` {
+		t.Errorf("valid Input must not be touched; got %q", got)
+	}
+}

--- a/messageutil.go
+++ b/messageutil.go
@@ -64,6 +64,11 @@ func (acc *Message) Accumulate(event MessageStreamEventUnion) error {
 			cb.Citations = append(cb.Citations, citation)
 		}
 	case MessageStopEvent:
+		// Sanitize invalid Input on any block before re-marshaling — see
+		// sanitizeContentBlockInput for the failure mode this guards against.
+		for i := range acc.Content {
+			sanitizeContentBlockInput(&acc.Content[i])
+		}
 		// Re-marshal the accumulated message to update JSON.raw so that AsAny()
 		// returns the accumulated data rather than the original stream data
 		accJSON, err := json.Marshal(acc)
@@ -78,6 +83,7 @@ func (acc *Message) Accumulate(event MessageStreamEventUnion) error {
 			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
 		}
 		contentBlock := &acc.Content[len(acc.Content)-1]
+		sanitizeContentBlockInput(contentBlock)
 		cbJSON, err := json.Marshal(contentBlock)
 		if err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)
@@ -86,6 +92,27 @@ func (acc *Message) Accumulate(event MessageStreamEventUnion) error {
 	}
 
 	return nil
+}
+
+// sanitizeContentBlockInput replaces a non-nil-but-invalid Input json.RawMessage
+// with []byte("{}") so the surrounding json.Marshal in Accumulate doesn't fail
+// the whole stream. Three real-world shapes hit this: an empty non-nil slice
+// (`""` in the start event), a truncated object (`{"argument":` when max_tokens
+// cuts off mid tool_use), and an unclosed string (`{"x": "abc`). All three
+// produce the same `unexpected end of JSON input` error from json.Compact
+// during marshal, even though the rest of the message accumulated fine. Patching
+// to `{}` rather than `null` keeps the tool_use structurally valid, so the
+// caller's tool dispatcher gets a real (if empty) object instead of having to
+// special-case `null`. Nil is left alone — it marshals as `null` cleanly and
+// carries the distinct "field absent" semantic.
+//
+// See https://github.com/anthropics/anthropic-sdk-go/issues/292 — reported as
+// "Streaming: json: error calling MarshalJSON for type json.RawMessage:
+// unexpected end of JSON input" when max_tokens is reached mid tool_use.
+func sanitizeContentBlockInput(cb *ContentBlockUnion) {
+	if cb.Input != nil && !json.Valid(cb.Input) {
+		cb.Input = []byte("{}")
+	}
 }
 
 // ToParam converters

--- a/messageutil_test.go
+++ b/messageutil_test.go
@@ -2,6 +2,7 @@ package anthropic_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -53,4 +54,84 @@ func TestContentBlockUnionToParam(t *testing.T) {
 			t.Errorf("Expected 1 search result in param, got %d", len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem))
 		}
 	})
+}
+
+// TestAccumulateRecoversFromInvalidToolUseInput pins the fix for
+// https://github.com/anthropics/anthropic-sdk-go/issues/292. Before the fix,
+// Accumulate's json.Marshal at content_block_stop / message_stop would fail
+// with "unexpected end of JSON input" whenever an input_json_delta sequence
+// left cb.Input as either empty-non-nil, truncated, or with an unclosed
+// string — typical when max_tokens cuts off mid tool_use. The fix replaces
+// such Input with []byte("{}") so the stream survives and the caller's tool
+// dispatcher gets a structurally valid tool_use to handle.
+func TestAccumulateRecoversFromInvalidToolUseInput(t *testing.T) {
+	for name, partials := range map[string][]string{
+		"empty non-nil":         {""},
+		"truncated":             {`{"argument":`},
+		"unclosed string":       {`{"x": "abc`},
+		"multi-delta truncated": {`{"args`, `ument":`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			events := []string{
+				`{"type": "message_start", "message": {"id": "msg_x", "type": "message", "role": "assistant", "content": [], "model": "test", "usage": {"input_tokens": 0, "output_tokens": 0}}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+			}
+			for _, partial := range partials {
+				events = append(events, fmt.Sprintf(
+					`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": %q}}`,
+					partial,
+				))
+			}
+			events = append(events,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_stop"}`,
+			)
+
+			message := anthropic.Message{}
+			for _, eventStr := range events {
+				event := anthropic.MessageStreamEventUnion{}
+				if err := (&event).UnmarshalJSON([]byte(eventStr)); err != nil {
+					t.Fatalf("unmarshal %s: %v", eventStr, err)
+				}
+				if err := (&message).Accumulate(event); err != nil {
+					t.Fatalf("Accumulate must not error on the malformed-input case; got %v", err)
+				}
+			}
+			if _, err := json.Marshal(message); err != nil {
+				t.Fatalf("json.Marshal must succeed after sanitisation; got %v", err)
+			}
+			if len(message.Content) != 1 {
+				t.Fatalf("expected one content block; got %d", len(message.Content))
+			}
+			if got := string(message.Content[0].Input); got != "{}" {
+				t.Errorf("Input should be sanitised to {}; got %q", got)
+			}
+		})
+	}
+}
+
+// TestAccumulateLeavesValidInputUntouched is the negative case for the same
+// fix: a tool_use whose accumulated Input is valid JSON must not be rewritten.
+func TestAccumulateLeavesValidInputUntouched(t *testing.T) {
+	events := []string{
+		`{"type": "message_start", "message": {"id": "msg_x", "type": "message", "role": "assistant", "content": [], "model": "test", "usage": {"input_tokens": 0, "output_tokens": 0}}}`,
+		`{"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_id", "name": "tool_name", "input": {}}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"argument\":"}}`,
+		`{"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": " \"value\"}"}}`,
+		`{"type": "content_block_stop", "index": 0}`,
+		`{"type": "message_stop"}`,
+	}
+	message := anthropic.Message{}
+	for _, eventStr := range events {
+		event := anthropic.MessageStreamEventUnion{}
+		if err := (&event).UnmarshalJSON([]byte(eventStr)); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if err := (&message).Accumulate(event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := string(message.Content[0].Input); got != `{"argument": "value"}` {
+		t.Errorf("valid Input must not be touched; got %q", got)
+	}
 }


### PR DESCRIPTION
Closes #292.

Repro: any streaming request that ends up with non-nil-but-invalid Input on a content block — empty slice (`""` in the start event), truncated object (`{"argument":` when max_tokens cuts off mid tool_use), or unclosed string (`{"x": "abc`) — fails the json.Marshal at content_block_stop / message_stop with

  json: error calling MarshalJSON for type json.RawMessage:
  unexpected end of JSON input

aborting the entire stream even though everything else accumulated fine. The encoder validates each RawMessage via json.Compact, so the issue isn't with Accumulate's own logic — it's that the value cb.Input ended up holding wouldn't round-trip.

Add sanitize{Content,BetaContent}BlockInput helpers that replace any non-nil-but-invalid Input with []byte("{}") just before the marshal sites, in both messageutil.go and betamessageutil.go. Patching to '{}' rather than 'null' (PR #307's approach) keeps the tool_use structurally valid so the caller's tool dispatcher gets a real object to handle — empty args is recoverable, having to special-case null isn't.

Nil Input is left alone — it marshals as 'null' cleanly and preserves the distinct "field absent" semantic.

Tests in messageutil_test.go and a new betamessageutil_test.go (matching the existing non-generated file convention) cover the four real shapes that trip the bug and assert valid Input stays untouched. Existing TestAccumulate and TestBetaAccumulate suites still pass.

Prior art: #307 attempted a similar fix from the inside (replacing invalid Input with null during in-flight accumulation) but the author withdrew it with uncertainty about the approach. This version is narrower — only the two stop-event marshal sites, only invalid Input, '{}' instead of null — so it doesn't change in-flight accumulation behavior, only stops the surrounding marshal from failing.