### PR TITLE
Fix accumulation when content blocks are interleaved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ${{ github.repository == 'stainless-sdks/anthropic-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     if: |-
-      github.repository == 'stainless-sdks/anthropic-go' &&
+      github.repository == 'github.com/anthropics/anthropic-sdk-go-private' &&
       (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get GitHub OIDC Token
         if: |-
-          github.repository == 'stainless-sdks/anthropic-go' &&
+          github.repository == 'github.com/anthropics/anthropic-sdk-go-private' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         id: github-oidc
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload tarball
         if: |-
-          github.repository == 'stainless-sdks/anthropic-go' &&
+          github.repository == 'github.com/anthropics/anthropic-sdk-go-private' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         env:
           URL: https://pkg.stainless.com/s
@@ -49,7 +49,7 @@ jobs:
   lint:
     timeout-minutes: 10
     name: lint
-    runs-on: ${{ github.repository == 'stainless-sdks/anthropic-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
 
     steps:
@@ -65,7 +65,7 @@ jobs:
   test:
     timeout-minutes: 10
     name: test
-    runs-on: ${{ github.repository == 'stainless-sdks/anthropic-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 106
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-e838393da0efc15ce03b38238db980e6ddc216215741569cc99782322bcfd000.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-65f060a87f2ec8bb0623b7abe4f1abebaf34ecc128a728745341c80f5aa13b84.yml
 openapi_spec_hash: 2790eecb0b38738a32441184273601a7
-config_hash: 09395de52178b00eb22c7c0f8090ee95
+config_hash: 54310fba9c4bfdd08adc5ba106a5b7a1

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 106
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-3044bdebca823a5e350accb2a228438e6ca5fb06cbac2cb1e0f98baa2bcc2359.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-d4dfef738a0eb8ab5a1e357a254134357302b99fb1718679749f8067be95052a.yml
 openapi_spec_hash: 2790eecb0b38738a32441184273601a7
-config_hash: 54a8475666d840df59a2a85a8c02b274
+config_hash: 802246d3edd0df77ec71824f41cd5718

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 106
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-e838393da0efc15ce03b38238db980e6ddc216215741569cc99782322bcfd000.yml
 openapi_spec_hash: 2790eecb0b38738a32441184273601a7
-config_hash: 70d06a7957e45a3ea82fb73a3f269ccc
+config_hash: 09395de52178b00eb22c7c0f8090ee95

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 106
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-65f060a87f2ec8bb0623b7abe4f1abebaf34ecc128a728745341c80f5aa13b84.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-0f82e75b4d5c8ce941f985650ff4a4abd9434f61c17c40f54023181f331c958c.yml
 openapi_spec_hash: 2790eecb0b38738a32441184273601a7
-config_hash: 54310fba9c4bfdd08adc5ba106a5b7a1
+config_hash: c56496cc00409842810eed6f4fc892b2

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 106
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-0f82e75b4d5c8ce941f985650ff4a4abd9434f61c17c40f54023181f331c958c.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-3044bdebca823a5e350accb2a228438e6ca5fb06cbac2cb1e0f98baa2bcc2359.yml
 openapi_spec_hash: 2790eecb0b38738a32441184273601a7
-config_hash: c56496cc00409842810eed6f4fc892b2
+config_hash: 54a8475666d840df59a2a85a8c02b274

--- a/betamessage_test.go
+++ b/betamessage_test.go
@@ -506,6 +506,23 @@ Therefore, the answer is..."}}`,
 				{Type: "text", Text: "The weather in Los Angeles is 85 degrees Fahrenheit!"},
 			}},
 		},
+		"interleaved content blocks": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}`,
+				`{"type": "content_block_start", "index": 1, "content_block": {"type": "thinking", "thinking": ""}}`,
+				`{"type": "content_block_delta", "index": 1, "delta": {"type": "thinking_delta", "thinking": "Thinking..."}}`,
+				`{"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " world"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "content_block_stop", "index": 1}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.BetaMessage{Content: []anthropic.BetaContentBlockUnion{
+				{Type: "text", Text: "Hello world"},
+				{Type: "thinking", Thinking: "Thinking..."},
+			}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			message := anthropic.BetaMessage{}

--- a/betamessage_test.go
+++ b/betamessage_test.go
@@ -453,6 +453,31 @@ Therefore, the answer is..."}}`,
 				{Type: "compaction", Content: anthropic.BetaContentBlockUnionContent{OfString: "Summary of the conversation so far."}},
 			}},
 		},
+		"refusal with stop_details and usage": {
+			events: []string{
+				`{"type": "message_start", "message": {}}`,
+				`{"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": "I cannot help"}}`,
+				`{"type": "content_block_stop", "index": 0}`,
+				`{"type": "message_delta", "delta": {"stop_reason": "refusal", "stop_details": {"type": "refusal", "category": "cyber", "explanation": "Declined by a streaming policy classifier."}}, "usage": {"input_tokens": 15, "output_tokens": 8, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0, "server_tool_use": {"web_search_requests": 2}}}`,
+				`{"type": "message_stop"}`,
+			},
+			expected: anthropic.BetaMessage{
+				Content: []anthropic.BetaContentBlockUnion{
+					{Type: "text", Text: "I cannot help"},
+				},
+				StopReason: "refusal",
+				StopDetails: anthropic.BetaRefusalStopDetails{
+					Type:        "refusal",
+					Category:    "cyber",
+					Explanation: "Declined by a streaming policy classifier.",
+				},
+				Usage: anthropic.BetaUsage{
+					InputTokens:   15,
+					OutputTokens:  8,
+					ServerToolUse: anthropic.BetaServerToolUsage{WebSearchRequests: 2},
+				},
+			},
+		},
 		"multiple content blocks": {
 			events: []string{
 				`{"type": "message_start", "message": {}}`,

--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -81,6 +81,7 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 			cb.Citations = append(cb.Citations, citation)
 		case BetaCompactionContentBlockDelta:
 			cb.Content.OfString = delta.Content
+			cb.EncryptedContent = delta.EncryptedContent
 		}
 	case BetaRawMessageStopEvent:
 		// Re-marshal the accumulated message to update JSON.raw so that AsAny()

--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -28,7 +28,22 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 	case BetaRawMessageDeltaEvent:
 		acc.StopReason = event.Delta.StopReason
 		acc.StopSequence = event.Delta.StopSequence
+		if event.Delta.JSON.StopDetails.Valid() {
+			acc.StopDetails = event.Delta.StopDetails
+		}
 		acc.Usage.OutputTokens = event.Usage.OutputTokens
+		if event.Usage.JSON.InputTokens.Valid() {
+			acc.Usage.InputTokens = event.Usage.InputTokens
+		}
+		if event.Usage.JSON.CacheCreationInputTokens.Valid() {
+			acc.Usage.CacheCreationInputTokens = event.Usage.CacheCreationInputTokens
+		}
+		if event.Usage.JSON.CacheReadInputTokens.Valid() {
+			acc.Usage.CacheReadInputTokens = event.Usage.CacheReadInputTokens
+		}
+		if event.Usage.JSON.ServerToolUse.Valid() {
+			acc.Usage.ServerToolUse = event.Usage.ServerToolUse
+		}
 		acc.Usage.Iterations = event.Usage.Iterations
 		acc.ContextManagement = event.ContextManagement
 	case BetaRawContentBlockStartEvent:

--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -47,16 +47,18 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 		acc.Usage.Iterations = event.Usage.Iterations
 		acc.ContextManagement = event.ContextManagement
 	case BetaRawContentBlockStartEvent:
-		acc.Content = append(acc.Content, BetaContentBlockUnion{})
-		err := acc.Content[len(acc.Content)-1].UnmarshalJSON([]byte(event.ContentBlock.RawJSON()))
+		for len(acc.Content) <= int(event.Index) {
+			acc.Content = append(acc.Content, BetaContentBlockUnion{})
+		}
+		err := acc.Content[int(event.Index)].UnmarshalJSON([]byte(event.ContentBlock.RawJSON()))
 		if err != nil {
 			return err
 		}
 	case BetaRawContentBlockDeltaEvent:
-		if len(acc.Content) == 0 {
-			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
+		if int(event.Index) >= len(acc.Content) {
+			return fmt.Errorf("received event of type %s for content block index %d but only %d content blocks exist", event.Type, event.Index, len(acc.Content))
 		}
-		cb := &acc.Content[len(acc.Content)-1]
+		cb := &acc.Content[int(event.Index)]
 		switch delta := event.Delta.AsAny().(type) {
 		case BetaTextDelta:
 			cb.Text += delta.Text
@@ -94,10 +96,10 @@ func (acc *BetaMessage) Accumulate(event BetaRawMessageStreamEventUnion) error {
 	case BetaRawContentBlockStopEvent:
 		// Re-marshal the content block to update JSON.raw so that AsAny()
 		// returns the accumulated data rather than the original stream data
-		if len(acc.Content) == 0 {
-			return fmt.Errorf("received event of type %s but there was no content block", event.Type)
+		if int(event.Index) >= len(acc.Content) {
+			return fmt.Errorf("received event of type %s for content block index %d but only %d content blocks exist", event.Type, event.Index, len(acc.Content))
 		}
-		contentBlock := &acc.Content[len(acc.Content)-1]
+		contentBlock := &acc.Content[int(event.Index)]
 		cbJSON, err := json.Marshal(contentBlock)
 		if err != nil {
 			return fmt.Errorf("error converting content block to JSON: %w", err)

--- a/messageutil.go
+++ b/messageutil.go
@@ -28,7 +28,22 @@ func (acc *Message) Accumulate(event MessageStreamEventUnion) error {
 	case MessageDeltaEvent:
 		acc.StopReason = event.Delta.StopReason
 		acc.StopSequence = event.Delta.StopSequence
+		if event.Delta.JSON.StopDetails.Valid() {
+			acc.StopDetails = event.Delta.StopDetails
+		}
 		acc.Usage.OutputTokens = event.Usage.OutputTokens
+		if event.Usage.JSON.InputTokens.Valid() {
+			acc.Usage.InputTokens = event.Usage.InputTokens
+		}
+		if event.Usage.JSON.CacheCreationInputTokens.Valid() {
+			acc.Usage.CacheCreationInputTokens = event.Usage.CacheCreationInputTokens
+		}
+		if event.Usage.JSON.CacheReadInputTokens.Valid() {
+			acc.Usage.CacheReadInputTokens = event.Usage.CacheReadInputTokens
+		}
+		if event.Usage.JSON.ServerToolUse.Valid() {
+			acc.Usage.ServerToolUse = event.Usage.ServerToolUse
+		}
 	case ContentBlockStartEvent:
 		acc.Content = append(acc.Content, ContentBlockUnion{})
 		err := acc.Content[len(acc.Content)-1].UnmarshalJSON([]byte(event.ContentBlock.RawJSON()))

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -43,7 +43,7 @@ UPLOAD_RESPONSE=$(curl -v -X PUT \
 
 if echo "$UPLOAD_RESPONSE" | grep -q "HTTP/[0-9.]* 200"; then
   echo -e "\033[32mUploaded build to Stainless storage.\033[0m"
-  echo -e "\033[32mInstallation: Download and unzip: 'https://pkg.stainless.com/s/anthropic-go/$SHA'. Run 'go mod edit -replace github.com/anthropics/anthropic-sdk-go=/path/to/unzipped_directory'.\033[0m"
+  echo -e "\033[32mInstallation: Download and unzip: 'https://pkg.stainless.com/s/anthropic-sdk-go-private/$SHA'. Run 'go mod edit -replace github.com/anthropics/anthropic-sdk-go=/path/to/unzipped_directory'.\033[0m"
 else
   echo -e "\033[31mFailed to upload artifact.\033[0m"
   exit 1


### PR DESCRIPTION
Fixes https://github.com/anthropics/anthropic-sdk-go/issues/350

### Summary

Fixes an issue in **Accumulate()** where content block deltas and stop events were applied to the most recently added content block instead of the block identified by **event.Index**.

This caused incorrect accumulation when content blocks were interleaved in the stream, for example when a new block starts before a previous block has finished receiving deltas.

The fix updates accumulation to use **event.Index** for:

- content_block_start
- content_block_delta
- content_block_stop

### Testing

Added a test case covering interleaved content blocks.

**Before this change:**

- the new test fails because deltas are incorrectly applied to the last content block

**After this change:**

- the new test passes
- existing tests continue to pass