### PR TITLE
fix: preserve server tool results in ToParam

### DIFF
--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -312,6 +312,9 @@ func (r BetaWebSearchToolResultBlock) ToParam() BetaWebSearchToolResultBlockPara
 	var p BetaWebSearchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
+	if r.JSON.Caller.Valid() {
+		p.Caller = param.Override[BetaWebSearchToolResultBlockParamCallerUnion](json.RawMessage(r.Caller.RawJSON()))
+	}
 
 	if len(r.Content.OfBetaWebSearchResultBlockArray) > 0 {
 		for _, block := range r.Content.OfBetaWebSearchResultBlockArray {
@@ -330,6 +333,10 @@ func (r BetaWebFetchToolResultBlock) ToParam() BetaWebFetchToolResultBlockParam 
 	var p BetaWebFetchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
+	p.Content = param.Override[BetaWebFetchToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
+	if r.JSON.Caller.Valid() {
+		p.Caller = param.Override[BetaWebFetchToolResultBlockParamCallerUnion](json.RawMessage(r.Caller.RawJSON()))
+	}
 	return p
 }
 

--- a/messageutil.go
+++ b/messageutil.go
@@ -238,6 +238,9 @@ func (r WebSearchToolResultBlock) ToParam() WebSearchToolResultBlockParam {
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
 	p.Content = r.Content.ToParam()
+	if r.JSON.Caller.Valid() {
+		p.Caller = param.Override[WebSearchToolResultBlockParamCallerUnion](json.RawMessage(r.Caller.RawJSON()))
+	}
 	return p
 }
 
@@ -301,6 +304,10 @@ func (r WebFetchToolResultBlock) ToParam() WebFetchToolResultBlockParam {
 	var p WebFetchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
+	p.Content = param.Override[WebFetchToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
+	if r.JSON.Caller.Valid() {
+		p.Caller = param.Override[WebFetchToolResultBlockParamCallerUnion](json.RawMessage(r.Caller.RawJSON()))
+	}
 	return p
 }
 

--- a/messageutil_test.go
+++ b/messageutil_test.go
@@ -2,11 +2,33 @@ package anthropic_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
 )
+
+func requireJSONEqual(t *testing.T, want string, got any) {
+	t.Helper()
+
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("Failed to marshal JSON: %v", err)
+	}
+
+	var wantValue any
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("Failed to unmarshal expected JSON: %v", err)
+	}
+	var gotValue any
+	if err := json.Unmarshal(gotJSON, &gotValue); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON: %v", err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("JSON mismatch:\n got: %s\nwant: %s", gotJSON, want)
+	}
+}
 
 func unmarshalContentBlockParam(t *testing.T, jsonData string) anthropic.ContentBlockParamUnion {
 	var block anthropic.ContentBlockUnion
@@ -52,5 +74,45 @@ func TestContentBlockUnionToParam(t *testing.T) {
 		if len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem) != 1 {
 			t.Errorf("Expected 1 search result in param, got %d", len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem))
 		}
+	})
+}
+
+func TestWebFetchToolResultBlockToParam(t *testing.T) {
+	const jsonData = `{"type":"web_fetch_tool_result","tool_use_id":"fetch123","caller":{"type":"direct"},"content":{"type":"web_fetch_result","url":"https://example.com","retrieved_at":"2026-05-30T00:00:00Z","content":{"type":"document","title":"Example","citations":{"enabled":true},"source":{"type":"text","data":"hello"}}}}`
+
+	t.Run("stable", func(t *testing.T) {
+		var block anthropic.ContentBlockUnion
+		if err := json.Unmarshal([]byte(jsonData), &block); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+		requireJSONEqual(t, jsonData, block.ToParam())
+	})
+
+	t.Run("beta", func(t *testing.T) {
+		var block anthropic.BetaContentBlockUnion
+		if err := json.Unmarshal([]byte(jsonData), &block); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+		requireJSONEqual(t, jsonData, block.ToParam())
+	})
+}
+
+func TestWebSearchToolResultBlockToParam(t *testing.T) {
+	const jsonData = `{"type":"web_search_tool_result","tool_use_id":"search123","caller":{"type":"direct"},"content":[{"type":"web_search_result","title":"Example","url":"https://example.com","encrypted_content":"abc123"}]}`
+
+	t.Run("stable", func(t *testing.T) {
+		var block anthropic.ContentBlockUnion
+		if err := json.Unmarshal([]byte(jsonData), &block); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+		requireJSONEqual(t, jsonData, block.ToParam())
+	})
+
+	t.Run("beta", func(t *testing.T) {
+		var block anthropic.BetaContentBlockUnion
+		if err := json.Unmarshal([]byte(jsonData), &block); err != nil {
+			t.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+		requireJSONEqual(t, jsonData, block.ToParam())
 	})
 }


### PR DESCRIPTION
## Summary

- preserve `web_fetch_tool_result.content` when response blocks are converted back into request params for multi-turn conversations
- preserve server-tool `caller` metadata for both web fetch and web search results
- apply the conversion fix consistently to stable and beta message utilities
- add JSON round-trip coverage for both tool-result families in both API surfaces

Addresses the web-fetch content-loss and caller-metadata portions of #346. The existing web-search content-array serialization path is unchanged; the round-trip regression pins that current JSON shape while this patch preserves its caller metadata.

## Validation

- `git diff --check`
- `gofmt -l messageutil.go betamessageutil.go messageutil_test.go`
- `GOMAXPROCS=2 go test -run 'TestWeb(Fetch|Search)ToolResultBlockToParam' .`

## Remote Linux validation
- `git diff --check`
- `./scripts/lint`
- `./scripts/bootstrap`
- `./scripts/test`