### PR TITLE
fix: decode beta string message content

### DIFF
--- a/betamessage.go
+++ b/betamessage.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"slices"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/packages/respjson"
 	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
+	"github.com/tidwall/gjson"
 )
 
 // BetaMessageService contains methods and other services that help with
@@ -3927,6 +3929,20 @@ func (u betaContentBlockParamUnionCaller) GetToolID() *string {
 		return vt.GetToolID()
 	}
 	return nil
+}
+
+func init() {
+	apijson.RegisterCustomDecoder[[]BetaContentBlockParamUnion](func(node gjson.Result, value reflect.Value, defaultDecoder func(gjson.Result, reflect.Value) error) error {
+		if node.Type == gjson.String {
+			textBlock := BetaTextBlockParam{Text: node.String(), Type: "text"}
+			contentUnion := BetaContentBlockParamUnion{OfText: &textBlock}
+			arrayValue := reflect.MakeSlice(value.Type(), 1, 1)
+			arrayValue.Index(0).Set(reflect.ValueOf(contentUnion))
+			value.Set(arrayValue)
+			return nil
+		}
+		return defaultDecoder(node, value)
+	})
 }
 
 func init() {
@@ -9247,6 +9263,20 @@ func (u betaToolResultBlockParamContentUnionSource) GetFileID() *string {
 		return vt.GetFileID()
 	}
 	return nil
+}
+
+func init() {
+	apijson.RegisterCustomDecoder[[]BetaToolResultBlockParamContentUnion](func(node gjson.Result, value reflect.Value, defaultDecoder func(gjson.Result, reflect.Value) error) error {
+		if node.Type == gjson.String {
+			textBlock := BetaTextBlockParam{Text: node.String(), Type: "text"}
+			contentUnion := BetaToolResultBlockParamContentUnion{OfText: &textBlock}
+			arrayValue := reflect.MakeSlice(value.Type(), 1, 1)
+			arrayValue.Index(0).Set(reflect.ValueOf(contentUnion))
+			value.Set(arrayValue)
+			return nil
+		}
+		return defaultDecoder(node, value)
+	})
 }
 
 func init() {

--- a/betamessage_test.go
+++ b/betamessage_test.go
@@ -617,3 +617,31 @@ func TestBetaAccumulateContentBlockIndexErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestBetaMessageNewParamsUnmarshalStringContent(t *testing.T) {
+	var params anthropic.BetaMessageNewParams
+	err := json.Unmarshal([]byte(`{"messages":[{"role":"user","content":"hello"}]}`), &params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(params.Messages) != 1 || len(params.Messages[0].Content) != 1 {
+		t.Fatalf("expected one content block, got %#v", params.Messages)
+	}
+	if got := params.Messages[0].Content[0].OfText.Text; got != "hello" {
+		t.Fatalf("expected content %q, got %q", "hello", got)
+	}
+}
+
+func TestBetaToolResultBlockParamUnmarshalStringContent(t *testing.T) {
+	var block anthropic.BetaToolResultBlockParam
+	err := json.Unmarshal([]byte(`{"type":"tool_result","tool_use_id":"toolu_id","content":"hello"}`), &block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(block.Content) != 1 {
+		t.Fatalf("expected one content block, got %#v", block.Content)
+	}
+	if got := block.Content[0].OfText.Text; got != "hello" {
+		t.Fatalf("expected content %q, got %q", "hello", got)
+	}
+}


### PR DESCRIPTION
## Summary
- register beta message-content string decoding with the same text-block shorthand supported by stable messages
- register the matching beta tool-result content decoder for stable/beta parity
- add focused regressions for both JSON shapes

## Context
Stable message params already decode string content into a single text block. Beta params currently omit the equivalent custom decoders, so unmarshalling valid shorthand such as `{"role":"user","content":"hello"}` silently leaves `Content` empty.

This is a current-main refresh of the string-content portion of #263, whose generated diff is now conflicting.

Fixes #343.

## Remote Linux validation
- `git diff --check`
- `./scripts/lint`
- `./scripts/bootstrap`
- `./scripts/test`