### PR TITLE
fix: double-encode text_editor_code_execution_tool_result content in ToParam()

### DIFF
--- a/beta_text_editor_roundtrip_test.go
+++ b/beta_text_editor_roundtrip_test.go
@@ -1,0 +1,61 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+)
+
+func TestBetaTextEditorCodeExecutionToolResultBlockRoundtrip(t *testing.T) {
+	// A non-error text_editor code-execution result block (beta), as the API returns it.
+	wire := `{
+		"type": "text_editor_code_execution_tool_result",
+		"tool_use_id": "srvtoolu_1",
+		"content": {
+			"type": "text_editor_code_execution_view_result",
+			"content": "line1\nline2\n",
+			"file_type": "text",
+			"num_lines": 2,
+			"start_line": 1,
+			"total_lines": 2
+		}
+	}`
+
+	var block anthropic.BetaContentBlockUnion
+	if err := json.Unmarshal([]byte(wire), &block); err != nil {
+		t.Fatal(err)
+	}
+
+	param := block.ToParam()
+	out, err := json.Marshal(param)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify content is a JSON object, not a quoted string
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	contentRaw := result["content"]
+	if len(contentRaw) == 0 {
+		t.Fatal("content field missing")
+	}
+
+	// The content should start with '{' (object), not '"' (string)
+	if contentRaw[0] == '"' {
+		t.Fatalf("content is double-encoded as JSON string: %s", string(contentRaw))
+	}
+
+	// Verify it's a valid JSON object
+	var contentObj map[string]interface{}
+	if err := json.Unmarshal(contentRaw, &contentObj); err != nil {
+		t.Fatalf("content is not a valid JSON object: %v", err)
+	}
+
+	if contentObj["type"] != "text_editor_code_execution_view_result" {
+		t.Fatalf("unexpected content type: %v", contentObj["type"])
+	}
+}

--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -369,7 +369,7 @@ func (r BetaTextEditorCodeExecutionToolResultBlock) ToParam() BetaTextEditorCode
 			ErrorMessage: paramutil.ToOpt(r.Content.ErrorMessage, r.Content.JSON.ErrorMessage),
 		}
 	} else {
-		p.Content = param.Override[BetaTextEditorCodeExecutionToolResultBlockParamContentUnion](r.Content.RawJSON())
+		p.Content = param.Override[BetaTextEditorCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	}
 	return p
 }

--- a/messageutil.go
+++ b/messageutil.go
@@ -380,7 +380,7 @@ func (r TextEditorCodeExecutionToolResultBlock) ToParam() TextEditorCodeExecutio
 			ErrorMessage: paramutil.ToOpt(r.Content.ErrorMessage, r.Content.JSON.ErrorMessage),
 		}
 	} else {
-		p.Content = param.Override[TextEditorCodeExecutionToolResultBlockParamContentUnion](r.Content.RawJSON())
+		p.Content = param.Override[TextEditorCodeExecutionToolResultBlockParamContentUnion](json.RawMessage(r.Content.RawJSON()))
 	}
 	return p
 }

--- a/text_editor_roundtrip_test.go
+++ b/text_editor_roundtrip_test.go
@@ -1,0 +1,61 @@
+package anthropic_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+)
+
+func TestTextEditorCodeExecutionToolResultBlockRoundtrip(t *testing.T) {
+	// A non-error text_editor code-execution result block, as the API returns it.
+	wire := `{
+		"type": "text_editor_code_execution_tool_result",
+		"tool_use_id": "srvtoolu_1",
+		"content": {
+			"type": "text_editor_code_execution_view_result",
+			"content": "line1\nline2\n",
+			"file_type": "text",
+			"num_lines": 2,
+			"start_line": 1,
+			"total_lines": 2
+		}
+	}`
+
+	var block anthropic.ContentBlockUnion
+	if err := json.Unmarshal([]byte(wire), &block); err != nil {
+		t.Fatal(err)
+	}
+
+	param := block.ToParam()
+	out, err := json.Marshal(param)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify content is a JSON object, not a quoted string
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	contentRaw := result["content"]
+	if len(contentRaw) == 0 {
+		t.Fatal("content field missing")
+	}
+
+	// The content should start with '{' (object), not '"' (string)
+	if contentRaw[0] == '"' {
+		t.Fatalf("content is double-encoded as JSON string: %s", string(contentRaw))
+	}
+
+	// Verify it's a valid JSON object
+	var contentObj map[string]interface{}
+	if err := json.Unmarshal(contentRaw, &contentObj); err != nil {
+		t.Fatalf("content is not a valid JSON object: %v", err)
+	}
+
+	if contentObj["type"] != "text_editor_code_execution_view_result" {
+		t.Fatalf("unexpected content type: %v", contentObj["type"])
+	}
+}


### PR DESCRIPTION
## Problem

`BetaTextEditorCodeExecutionToolResultBlock.ToParam()` and `TextEditorCodeExecutionToolResultBlock.ToParam()` double-encode the `content` of non-error results as a JSON **string** instead of a JSON **object**. This makes it impossible to round-trip a `text_editor_code_execution_tool_result` response block back into a follow-up request.

## Root Cause

The non-error branch passes `r.Content.RawJSON()` (a Go `string`) to `param.Override()`. Since `param.Override` stores the value as-is and marshals it later, a plain string gets JSON-encoded as a quoted string rather than inlined as raw JSON.

```go
// Before — RawJSON() returns string, gets marshaled as "..."
p.Content = param.Override[...](r.Content.RawJSON())
```

## Fix

Wrap with `json.RawMessage()` so the content is serialized as a structured object:

```go
// After — json.RawMessage inlines the JSON object
p.Content = param.Override[...](json.RawMessage(r.Content.RawJSON()))
```

This matches the pattern used by `BetaBashCodeExecutionToolResultBlock.ToParam()` (which reconstructs fields explicitly) and is consistent with `param.Override`'s documented usage.

## Files Changed

- `betamessageutil.go` — fix `BetaTextEditorCodeExecutionToolResultBlock.ToParam()`
- `messageutil.go` — fix `TextEditorCodeExecutionToolResultBlock.ToParam()`
- Added roundtrip tests for both beta and non-beta variants

Fixes #355
