### PR TITLE
fix: preserve web tool result ToParam payloads

### DIFF
--- a/betamessage.go
+++ b/betamessage.go
@@ -11664,7 +11664,15 @@ type BetaWebSearchToolResultBlockParamContentUnion struct {
 }
 
 func (u BetaWebSearchToolResultBlockParamContentUnion) MarshalJSON() ([]byte, error) {
-	return param.MarshalUnion(u, u.OfResultBlock, u.OfError)
+	var resultList *struct {
+		List []BetaWebSearchResultBlockParam `json:"list"`
+	}
+	if !param.IsOmitted(u.OfResultBlock) {
+		resultList = &struct {
+			List []BetaWebSearchResultBlockParam `json:"list"`
+		}{List: u.OfResultBlock}
+	}
+	return param.MarshalUnion(u, resultList, u.OfError)
 }
 func (u *BetaWebSearchToolResultBlockParamContentUnion) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, u)

--- a/betamessageutil.go
+++ b/betamessageutil.go
@@ -334,6 +334,7 @@ func (r BetaWebSearchToolResultBlock) ToParam() BetaWebSearchToolResultBlockPara
 	var p BetaWebSearchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
+	p.Caller = r.Caller.ToParam()
 
 	if len(r.Content.OfBetaWebSearchResultBlockArray) > 0 {
 		for _, block := range r.Content.OfBetaWebSearchResultBlockArray {
@@ -348,11 +349,61 @@ func (r BetaWebSearchToolResultBlock) ToParam() BetaWebSearchToolResultBlockPara
 	return p
 }
 
+func (u BetaWebSearchToolResultBlockCallerUnion) ToParam() BetaWebSearchToolResultBlockParamCallerUnion {
+	switch u.Type {
+	case "direct":
+		v := u.AsDirect().ToParam()
+		return BetaWebSearchToolResultBlockParamCallerUnion{OfDirect: &v}
+	case "code_execution_20250825":
+		v := u.AsCodeExecution20250825().ToParam()
+		return BetaWebSearchToolResultBlockParamCallerUnion{OfCodeExecution20250825: &v}
+	case "code_execution_20260120":
+		v := u.AsCodeExecution20260120().ToParam()
+		return BetaWebSearchToolResultBlockParamCallerUnion{OfCodeExecution20260120: &v}
+	default:
+		return BetaWebSearchToolResultBlockParamCallerUnion{}
+	}
+}
+
 func (r BetaWebFetchToolResultBlock) ToParam() BetaWebFetchToolResultBlockParam {
 	var p BetaWebFetchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
+	p.Content = r.Content.ToParam()
+	p.Caller = r.Caller.ToParam()
 	return p
+}
+
+func (r BetaWebFetchToolResultBlockContentUnion) ToParam() BetaWebFetchToolResultBlockParamContentUnion {
+	var p BetaWebFetchToolResultBlockParamContentUnion
+	if r.JSON.ErrorCode.Valid() {
+		p.OfRequestWebFetchToolResultError = &BetaWebFetchToolResultErrorBlockParam{
+			ErrorCode: r.ErrorCode,
+		}
+	} else {
+		p.OfRequestWebFetchResultBlock = &BetaWebFetchBlockParam{
+			URL:         r.URL,
+			RetrievedAt: paramutil.ToOpt(r.RetrievedAt, r.JSON.RetrievedAt),
+			Content:     param.Override[BetaRequestDocumentBlockParam](json.RawMessage(r.Content.RawJSON())),
+		}
+	}
+	return p
+}
+
+func (u BetaWebFetchToolResultBlockCallerUnion) ToParam() BetaWebFetchToolResultBlockParamCallerUnion {
+	switch u.Type {
+	case "direct":
+		v := u.AsDirect().ToParam()
+		return BetaWebFetchToolResultBlockParamCallerUnion{OfDirect: &v}
+	case "code_execution_20250825":
+		v := u.AsCodeExecution20250825().ToParam()
+		return BetaWebFetchToolResultBlockParamCallerUnion{OfCodeExecution20250825: &v}
+	case "code_execution_20260120":
+		v := u.AsCodeExecution20260120().ToParam()
+		return BetaWebFetchToolResultBlockParamCallerUnion{OfCodeExecution20260120: &v}
+	default:
+		return BetaWebFetchToolResultBlockParamCallerUnion{}
+	}
 }
 
 func (r BetaMCPToolUseBlock) ToParam() BetaMCPToolUseBlockParam {

--- a/message.go
+++ b/message.go
@@ -9219,7 +9219,15 @@ type WebSearchToolResultBlockParamContentUnion struct {
 }
 
 func (u WebSearchToolResultBlockParamContentUnion) MarshalJSON() ([]byte, error) {
-	return param.MarshalUnion(u, u.OfWebSearchToolResultBlockItem, u.OfRequestWebSearchToolResultError)
+	var resultList *struct {
+		List []WebSearchResultBlockParam `json:"list"`
+	}
+	if !param.IsOmitted(u.OfWebSearchToolResultBlockItem) {
+		resultList = &struct {
+			List []WebSearchResultBlockParam `json:"list"`
+		}{List: u.OfWebSearchToolResultBlockItem}
+	}
+	return param.MarshalUnion(u, resultList, u.OfRequestWebSearchToolResultError)
 }
 func (u *WebSearchToolResultBlockParamContentUnion) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, u)

--- a/messageutil.go
+++ b/messageutil.go
@@ -270,6 +270,7 @@ func (r WebSearchToolResultBlock) ToParam() WebSearchToolResultBlockParam {
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
 	p.Content = r.Content.ToParam()
+	p.Caller = r.Caller.ToParam()
 	return p
 }
 
@@ -297,6 +298,22 @@ func (r WebSearchToolResultBlockContentUnion) ToParam() WebSearchToolResultBlock
 		ErrorCode: WebSearchToolResultErrorCode(r.ErrorCode),
 	}
 	return p
+}
+
+func (u WebSearchToolResultBlockCallerUnion) ToParam() WebSearchToolResultBlockParamCallerUnion {
+	switch u.Type {
+	case "direct":
+		v := u.AsDirect().ToParam()
+		return WebSearchToolResultBlockParamCallerUnion{OfDirect: &v}
+	case "code_execution_20250825":
+		v := u.AsCodeExecution20250825().ToParam()
+		return WebSearchToolResultBlockParamCallerUnion{OfCodeExecution20250825: &v}
+	case "code_execution_20260120":
+		v := u.AsCodeExecution20260120().ToParam()
+		return WebSearchToolResultBlockParamCallerUnion{OfCodeExecution20260120: &v}
+	default:
+		return WebSearchToolResultBlockParamCallerUnion{}
+	}
 }
 
 func (variant WebFetchToolResultBlock) toParamUnion() ContentBlockParamUnion {
@@ -333,7 +350,41 @@ func (r WebFetchToolResultBlock) ToParam() WebFetchToolResultBlockParam {
 	var p WebFetchToolResultBlockParam
 	p.Type = r.Type
 	p.ToolUseID = r.ToolUseID
+	p.Content = r.Content.ToParam()
+	p.Caller = r.Caller.ToParam()
 	return p
+}
+
+func (r WebFetchToolResultBlockContentUnion) ToParam() WebFetchToolResultBlockParamContentUnion {
+	var p WebFetchToolResultBlockParamContentUnion
+	if r.JSON.ErrorCode.Valid() {
+		p.OfRequestWebFetchToolResultError = &WebFetchToolResultErrorBlockParam{
+			ErrorCode: r.ErrorCode,
+		}
+	} else {
+		p.OfRequestWebFetchResultBlock = &WebFetchBlockParam{
+			URL:         r.URL,
+			RetrievedAt: paramutil.ToOpt(r.RetrievedAt, r.JSON.RetrievedAt),
+			Content:     param.Override[DocumentBlockParam](json.RawMessage(r.Content.RawJSON())),
+		}
+	}
+	return p
+}
+
+func (u WebFetchToolResultBlockCallerUnion) ToParam() WebFetchToolResultBlockParamCallerUnion {
+	switch u.Type {
+	case "direct":
+		v := u.AsDirect().ToParam()
+		return WebFetchToolResultBlockParamCallerUnion{OfDirect: &v}
+	case "code_execution_20250825":
+		v := u.AsCodeExecution20250825().ToParam()
+		return WebFetchToolResultBlockParamCallerUnion{OfCodeExecution20250825: &v}
+	case "code_execution_20260120":
+		v := u.AsCodeExecution20260120().ToParam()
+		return WebFetchToolResultBlockParamCallerUnion{OfCodeExecution20260120: &v}
+	default:
+		return WebFetchToolResultBlockParamCallerUnion{}
+	}
 }
 
 func (r ContainerUploadBlock) ToParam() ContainerUploadBlockParam {

--- a/messageutil_test.go
+++ b/messageutil_test.go
@@ -18,6 +18,39 @@ func unmarshalContentBlockParam(t *testing.T, jsonData string) anthropic.Content
 	return result
 }
 
+func marshalContentBlockParamObject(t *testing.T, jsonData string) map[string]any {
+	t.Helper()
+
+	paramBlock := unmarshalContentBlockParam(t, jsonData)
+	data, err := json.Marshal(paramBlock)
+	if err != nil {
+		t.Fatalf("Failed to marshal param JSON: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to decode marshaled param JSON: %v\nJSON: %s", err, data)
+	}
+	return result
+}
+
+func marshalBetaContentBlockParamObject(t *testing.T, jsonData string) map[string]any {
+	t.Helper()
+
+	var block anthropic.BetaContentBlockUnion
+	if err := json.Unmarshal([]byte(jsonData), &block); err != nil {
+		t.Fatalf("Failed to unmarshal beta JSON: %v", err)
+	}
+	data, err := json.Marshal(block.ToParam())
+	if err != nil {
+		t.Fatalf("Failed to marshal beta param JSON: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to decode marshaled beta param JSON: %v\nJSON: %s", err, data)
+	}
+	return result
+}
+
 func TestContentBlockUnionToParam(t *testing.T) {
 	t.Run("TextBlock with text only", func(t *testing.T) {
 		result := unmarshalContentBlockParam(t, `{"type":"text","text":"Hello, world!"}`)
@@ -51,6 +84,126 @@ func TestContentBlockUnionToParam(t *testing.T) {
 		}
 		if len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem) != 1 {
 			t.Errorf("Expected 1 search result in param, got %d", len(result.OfWebSearchToolResult.Content.OfWebSearchToolResultBlockItem))
+		}
+	})
+
+	t.Run("WebSearchToolResultBlock marshals search results under list and preserves caller", func(t *testing.T) {
+		result := marshalContentBlockParamObject(t, `{
+			"type":"web_search_tool_result",
+			"tool_use_id":"toolu_search_123",
+			"caller":{"type":"code_execution_20250825","tool_id":"srvtool_123"},
+			"content":[{"type":"web_search_result","title":"Example Article","url":"https://example.com/article","encrypted_content":"abc123","page_age":"1 day ago"}]
+		}`)
+
+		content, ok := result["content"].(map[string]any)
+		if !ok {
+			t.Fatalf("content = %#v, want object with list", result["content"])
+		}
+		list, ok := content["list"].([]any)
+		if !ok || len(list) != 1 {
+			t.Fatalf("content.list = %#v, want one result", content["list"])
+		}
+		caller, ok := result["caller"].(map[string]any)
+		if !ok {
+			t.Fatalf("caller = %#v, want object", result["caller"])
+		}
+		if caller["type"] != "code_execution_20250825" || caller["tool_id"] != "srvtool_123" {
+			t.Fatalf("caller = %#v, want code execution caller", caller)
+		}
+	})
+
+	t.Run("WebFetchToolResultBlock marshals content and preserves caller", func(t *testing.T) {
+		result := marshalContentBlockParamObject(t, `{
+			"type":"web_fetch_tool_result",
+			"tool_use_id":"toolu_fetch_456",
+			"caller":{"type":"code_execution_20250825","tool_id":"srvtool_456"},
+			"content":{
+				"type":"web_fetch_result",
+				"url":"https://example.com/article",
+				"retrieved_at":"2026-01-01T00:00:00Z",
+				"content":{
+					"type":"document",
+					"title":"Example Article",
+					"citations":{"enabled":false},
+					"source":{"type":"text","media_type":"text/plain","data":"Fetched body"}
+				}
+			}
+		}`)
+
+		content, ok := result["content"].(map[string]any)
+		if !ok {
+			t.Fatalf("content = %#v, want object", result["content"])
+		}
+		if content["type"] != "web_fetch_result" || content["url"] != "https://example.com/article" {
+			t.Fatalf("content = %#v, want web fetch result", content)
+		}
+		caller, ok := result["caller"].(map[string]any)
+		if !ok {
+			t.Fatalf("caller = %#v, want object", result["caller"])
+		}
+		if caller["type"] != "code_execution_20250825" || caller["tool_id"] != "srvtool_456" {
+			t.Fatalf("caller = %#v, want code execution caller", caller)
+		}
+	})
+}
+
+func TestBetaContentBlockUnionToParamWebToolResults(t *testing.T) {
+	t.Run("BetaWebSearchToolResultBlock marshals search results under list and preserves caller", func(t *testing.T) {
+		result := marshalBetaContentBlockParamObject(t, `{
+			"type":"web_search_tool_result",
+			"tool_use_id":"toolu_search_beta",
+			"caller":{"type":"code_execution_20250825","tool_id":"srvtool_beta_search"},
+			"content":[{"type":"web_search_result","title":"Example Article","url":"https://example.com/article","encrypted_content":"abc123","page_age":"1 day ago"}]
+		}`)
+
+		content, ok := result["content"].(map[string]any)
+		if !ok {
+			t.Fatalf("content = %#v, want object with list", result["content"])
+		}
+		list, ok := content["list"].([]any)
+		if !ok || len(list) != 1 {
+			t.Fatalf("content.list = %#v, want one result", content["list"])
+		}
+		caller, ok := result["caller"].(map[string]any)
+		if !ok {
+			t.Fatalf("caller = %#v, want object", result["caller"])
+		}
+		if caller["type"] != "code_execution_20250825" || caller["tool_id"] != "srvtool_beta_search" {
+			t.Fatalf("caller = %#v, want code execution caller", caller)
+		}
+	})
+
+	t.Run("BetaWebFetchToolResultBlock marshals content and preserves caller", func(t *testing.T) {
+		result := marshalBetaContentBlockParamObject(t, `{
+			"type":"web_fetch_tool_result",
+			"tool_use_id":"toolu_fetch_beta",
+			"caller":{"type":"code_execution_20250825","tool_id":"srvtool_beta_fetch"},
+			"content":{
+				"type":"web_fetch_result",
+				"url":"https://example.com/article",
+				"retrieved_at":"2026-01-01T00:00:00Z",
+				"content":{
+					"type":"document",
+					"title":"Example Article",
+					"citations":{"enabled":false},
+					"source":{"type":"text","media_type":"text/plain","data":"Fetched body"}
+				}
+			}
+		}`)
+
+		content, ok := result["content"].(map[string]any)
+		if !ok {
+			t.Fatalf("content = %#v, want object", result["content"])
+		}
+		if content["type"] != "web_fetch_result" || content["url"] != "https://example.com/article" {
+			t.Fatalf("content = %#v, want web fetch result", content)
+		}
+		caller, ok := result["caller"].(map[string]any)
+		if !ok {
+			t.Fatalf("caller = %#v, want object", result["caller"])
+		}
+		if caller["type"] != "code_execution_20250825" || caller["tool_id"] != "srvtool_beta_fetch" {
+			t.Fatalf("caller = %#v, want code execution caller", caller)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
Fixes `Message.ToParam()` round-tripping for server-side `web_search_tool_result` and `web_fetch_tool_result` blocks in multi-turn conversations.

The previous conversion produced a bare array for web search results and omitted web fetch result content entirely, so sending an assistant message back through `ToParam()` could produce request JSON rejected by the API.

## Changes
- Marshal web search tool result content under the request-side `list` wrapper.
- Preserve caller metadata for web search and web fetch tool results.
- Copy web fetch result/error content into request params for stable and beta message paths.
- Add stable and beta regression coverage for marshaled `ToParam()` output.

Fixes #346

## Tests
- `go test . -run 'Test(ContentBlockUnionToParam|BetaContentBlockUnionToParamWebToolResults)$' -count=1`
- `git diff --check`

Note: `go test .` was also attempted locally, but the package test binary hung with no output and had to be stopped. The targeted regression tests above complete successfully.
