### PR TITLE
fix(agenttoolset): allow workdir absolute paths

### DIFF
--- a/betaagent.go
+++ b/betaagent.go
@@ -865,8 +865,9 @@ func (r *BetaManagedAgentsAgentToolset20260401EditInput) UnmarshalJSON(data []by
 // Input payload for the `glob` tool. Returns paths matching a doublestar glob
 // pattern, newest first.
 type BetaManagedAgentsAgentToolset20260401GlobInput struct {
-	// Doublestar glob pattern (e.g. `**/*.go`). Absolute patterns are only permitted
-	// when the runner is configured to allow them.
+	// Doublestar glob pattern (e.g. `**/*.go`). Absolute patterns are permitted
+	// when they resolve under the runner's working directory, or when the runner is
+	// configured to allow unrestricted paths.
 	Pattern string `json:"pattern" api:"required"`
 	// Optional directory root to search under. Defaults to the runner's working
 	// directory.

--- a/tools/agenttoolset/agenttoolset.go
+++ b/tools/agenttoolset/agenttoolset.go
@@ -57,9 +57,10 @@ import (
 type AgentToolContext struct {
 	// Workdir is the base directory for resolving relative tool paths.
 	Workdir string
-	// UnrestrictedPaths controls whether the file tools accept absolute paths
-	// and paths that escape Workdir. When false (default) they are rejected.
-	// Does not constrain [BetaBashTool].
+	// UnrestrictedPaths controls whether the file tools accept paths that
+	// escape Workdir. When false (default), relative paths and absolute paths
+	// are accepted only if they resolve inside Workdir. Does not constrain
+	// [BetaBashTool].
 	UnrestrictedPaths bool
 
 	// MaxFileBytes caps the size of a file the read and edit tools will load
@@ -178,7 +179,7 @@ func fsErrorMessage(err error) string {
 }
 
 // resolvePath resolves p relative to env.Workdir. Unless UnrestrictedPaths is
-// set, absolute inputs are rejected and the canonical path is returned — every
+// set, the canonical path is returned only if it stays under Workdir — every
 // symlink in p (including the leaf, even a dangling one) is resolved before the
 // workdir check, and the resolved path is what the tool then operates on, so a
 // symlink inside the workdir that points outside it can neither pass the check
@@ -190,22 +191,23 @@ func fsErrorMessage(err error) string {
 // same residual exposure exists in the SDK's other file-tool helpers and is why
 // a sandbox is still recommended for the toolset as a whole.
 func resolvePath(env *AgentToolContext, p string) (string, error) {
-	if filepath.IsAbs(p) {
-		if !env.UnrestrictedPaths {
-			return "", fmt.Errorf("absolute path %q not permitted", p)
-		}
-		return filepath.Clean(p), nil
-	}
 	root := realpathOrSelf(absOrSelf(env.Workdir))
-	abs := filepath.Join(root, p)
+	abs := p
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(root, p)
+	}
 	if env.UnrestrictedPaths {
-		return abs, nil
+		return filepath.Clean(abs), nil
 	}
 	real := canonicalize(abs)
-	if real != root && !strings.HasPrefix(real, root+string(filepath.Separator)) {
+	if !isPathWithinRoot(real, root) {
 		return "", fmt.Errorf("path %q escapes workdir", p)
 	}
 	return real, nil
+}
+
+func isPathWithinRoot(p, root string) bool {
+	return p == root || strings.HasPrefix(p, root+string(filepath.Separator))
 }
 
 func absOrSelf(p string) string {

--- a/tools/agenttoolset/agenttoolset_test.go
+++ b/tools/agenttoolset/agenttoolset_test.go
@@ -55,9 +55,21 @@ func TestResolvePath(t *testing.T) {
 			want:        filepath.Join(absWork, "c.txt"),
 		},
 		{
-			description: "absolute path is rejected when UnrestrictedPaths is false",
+			description: "absolute path inside the workdir resolves when UnrestrictedPaths is false",
+			env:         &AgentToolContext{Workdir: work},
+			input:       filepath.Join(absWork, "d.txt"),
+			want:        filepath.Join(absWork, "d.txt"),
+		},
+		{
+			description: "absolute path outside the workdir is rejected when UnrestrictedPaths is false",
 			env:         &AgentToolContext{Workdir: work},
 			input:       "/etc/passwd",
+			wantErr:     true,
+		},
+		{
+			description: "absolute sibling path that string-prefixes the workdir is rejected when UnrestrictedPaths is false",
+			env:         &AgentToolContext{Workdir: work},
+			input:       sibling,
 			wantErr:     true,
 		},
 		{
@@ -107,6 +119,8 @@ func TestResolvePathConfinesSymlinks(t *testing.T) {
 	require.NoError(t, os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(work, "live")))
 	_, err := resolvePath(env, "live")
 	require.Error(t, err, "a symlink inside the workdir that points outside it must be rejected")
+	_, err = resolvePath(env, filepath.Join(realpathOrSelf(absOrSelf(work)), "live"))
+	require.Error(t, err, "an absolute symlink inside the workdir that points outside it must be rejected")
 
 	// Dangling target outside the workdir.
 	require.NoError(t, os.Symlink(filepath.Join(outside, "nope.txt"), filepath.Join(work, "dangling")))

--- a/tools/agenttoolset/fs.go
+++ b/tools/agenttoolset/fs.go
@@ -36,9 +36,9 @@ func resolveMaxBytes(configured, def int64) (limit int64, capped bool) {
 func BetaReadTool(env *AgentToolContext) anthropic.BetaTool {
 	return &funcTool{
 		name:        "read",
-		description: "Read a UTF-8 text file relative to the workdir.",
+		description: "Read a UTF-8 text file under the workdir.",
 		schema: objectSchema(map[string]any{
-			"file_path": prop("string", "Path of the file to read, relative to the workdir."),
+			"file_path": prop("string", "Path of the file to read, relative to the workdir or absolute under it."),
 			"view_range": map[string]any{
 				"type":        "array",
 				"items":       map[string]any{"type": "integer"},
@@ -55,9 +55,9 @@ func BetaReadTool(env *AgentToolContext) anthropic.BetaTool {
 func BetaWriteTool(env *AgentToolContext) anthropic.BetaTool {
 	return &funcTool{
 		name:        "write",
-		description: "Write a UTF-8 text file relative to the workdir, creating parent directories as needed.",
+		description: "Write a UTF-8 text file under the workdir, creating parent directories as needed.",
 		schema: objectSchema(map[string]any{
-			"file_path": prop("string", "Path of the file to write, relative to the workdir."),
+			"file_path": prop("string", "Path of the file to write, relative to the workdir or absolute under it."),
 			"content":   prop("string", "Full file contents to write."),
 		}, "file_path", "content"),
 		env: env,
@@ -72,7 +72,7 @@ func BetaEditTool(env *AgentToolContext) anthropic.BetaTool {
 		name:        "edit",
 		description: "Replace a unique occurrence of old_string with new_string in a file (set replace_all to replace every occurrence).",
 		schema: objectSchema(map[string]any{
-			"file_path":   prop("string", "Path of the file to edit, relative to the workdir."),
+			"file_path":   prop("string", "Path of the file to edit, relative to the workdir or absolute under it."),
 			"old_string":  prop("string", "Substring to find and replace."),
 			"new_string":  prop("string", "Replacement text."),
 			"replace_all": prop("boolean", "Replace every occurrence instead of requiring a unique match."),

--- a/tools/agenttoolset/search.go
+++ b/tools/agenttoolset/search.go
@@ -32,8 +32,8 @@ func BetaGlobTool(env *AgentToolContext) anthropic.BetaTool {
 		name:        "glob",
 		description: "List paths matching a glob pattern (e.g. **/*.go), newest first.",
 		schema: objectSchema(map[string]any{
-			"pattern": prop("string", "Glob pattern, e.g. **/*.go (** matches any depth)."),
-			"path":    prop("string", "Directory to search in. Defaults to the workdir."),
+			"pattern": prop("string", "Glob pattern, e.g. **/*.go (** matches any depth), or an absolute pattern under the workdir."),
+			"path":    prop("string", "Directory to search in, relative to the workdir or absolute under it. Defaults to the workdir."),
 		}, "pattern"),
 		env: env,
 		run: execGlob,
@@ -48,7 +48,7 @@ func BetaGrepTool(env *AgentToolContext) anthropic.BetaTool {
 		description: "Search file contents for a regex. Uses ripgrep if available, otherwise a built-in walker.",
 		schema: objectSchema(map[string]any{
 			"pattern": prop("string", "Regular expression to search for."),
-			"path":    prop("string", "Directory to search in. Defaults to the workdir."),
+			"path":    prop("string", "Directory to search in, relative to the workdir or absolute under it. Defaults to the workdir."),
 		}, "pattern"),
 		env: env,
 		run: execGrep,
@@ -67,11 +67,11 @@ func execGlob(_ context.Context, raw json.RawMessage, env *AgentToolContext) (st
 	root := env.Workdir
 	pattern := in.Pattern
 	if filepath.IsAbs(pattern) {
-		if !env.UnrestrictedPaths {
-			return errorf("glob: absolute pattern not permitted")
+		var err error
+		root, pattern, err = resolveAbsoluteGlobPattern(env, pattern)
+		if err != nil {
+			return errorf("glob: %v", err)
 		}
-		root = "/"
-		pattern = strings.TrimPrefix(pattern, "/")
 	} else if in.Path != "" {
 		p, err := resolvePath(env, in.Path)
 		if err != nil {
@@ -155,6 +155,57 @@ func hasParentDirSegment(pattern string) bool {
 		}
 	}
 	return false
+}
+
+func resolveAbsoluteGlobPattern(env *AgentToolContext, pattern string) (string, string, error) {
+	if env.UnrestrictedPaths {
+		return string(filepath.Separator), strings.TrimPrefix(pattern, string(filepath.Separator)), nil
+	}
+	if hasParentDirSegment(pattern) {
+		return "", "", fmt.Errorf("pattern %q must not contain a %q segment", pattern, "..")
+	}
+	root := realpathOrSelf(absOrSelf(env.Workdir))
+	prefix, suffix := splitGlobLiteralPrefix(pattern)
+	realPrefix := canonicalize(prefix)
+	if !isPathWithinRoot(realPrefix, root) {
+		return "", "", fmt.Errorf("pattern %q escapes workdir", pattern)
+	}
+	relPrefix, err := filepath.Rel(root, realPrefix)
+	if err != nil {
+		return "", "", err
+	}
+	return root, joinGlobPattern(relPrefix, suffix), nil
+}
+
+func splitGlobLiteralPrefix(pattern string) (string, string) {
+	meta := strings.IndexAny(pattern, "*?[")
+	if meta < 0 {
+		return filepath.Clean(pattern), ""
+	}
+	prefixEnd := strings.LastIndex(pattern[:meta], string(filepath.Separator))
+	if prefixEnd < 0 {
+		return ".", pattern
+	}
+	if prefixEnd == 0 {
+		return string(filepath.Separator), pattern[1:]
+	}
+	return filepath.Clean(pattern[:prefixEnd]), pattern[prefixEnd+1:]
+}
+
+func joinGlobPattern(prefix, suffix string) string {
+	if prefix == "." {
+		prefix = ""
+	}
+	prefix = filepath.ToSlash(prefix)
+	suffix = filepath.ToSlash(suffix)
+	switch {
+	case prefix == "":
+		return suffix
+	case suffix == "":
+		return prefix
+	default:
+		return prefix + "/" + suffix
+	}
 }
 
 // globMatch reports whether rel — a slash-separated path relative to the search

--- a/tools/agenttoolset/search_test.go
+++ b/tools/agenttoolset/search_test.go
@@ -26,10 +26,14 @@ func TestExecGlob(t *testing.T) {
 	write("b.go", now)
 	write("sub/c.go", now.Add(-1*time.Hour))
 	write("d.txt", now)
+	sibling := work + "extra"
+	require.NoError(t, os.MkdirAll(sibling, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sibling, "secret.go"), []byte("x"), 0o644))
 
 	tests := []struct {
 		description string
 		pattern     string
+		path        string
 		assert      func(t *testing.T, lines []string)
 		wantErr     bool
 	}{
@@ -57,8 +61,21 @@ func TestExecGlob(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			description: "absolute pattern is rejected when UnrestrictedPaths is false",
-			pattern:     "/etc/*",
+			description: "absolute pattern inside the workdir is confined and matched",
+			pattern:     filepath.Join(work, "sub", "*.go"),
+			assert: func(t *testing.T, lines []string) {
+				require.Len(t, lines, 1)
+				require.True(t, strings.HasSuffix(lines[0], filepath.Join("sub", "c.go")), "expected sub/c.go, got %q", lines[0])
+			},
+		},
+		{
+			description: "absolute pattern outside the workdir is rejected when UnrestrictedPaths is false",
+			pattern:     filepath.Join(sibling, "*.go"),
+			wantErr:     true,
+		},
+		{
+			description: "absolute pattern with a .. segment is rejected even when it normalizes inside the workdir",
+			pattern:     work + string(filepath.Separator) + "sub" + string(filepath.Separator) + ".." + string(filepath.Separator) + "*.go",
 			wantErr:     true,
 		},
 		{
@@ -75,7 +92,11 @@ func TestExecGlob(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			out, isErr := execGlob(context.Background(), mustJSON(t, map[string]any{"pattern": tc.pattern}), env)
+			input := map[string]any{"pattern": tc.pattern}
+			if tc.path != "" {
+				input["path"] = tc.path
+			}
+			out, isErr := execGlob(context.Background(), mustJSON(t, input), env)
 			require.Equal(t, tc.wantErr, isErr, "output=%q", out)
 			if tc.wantErr || tc.assert == nil {
 				return
@@ -96,6 +117,13 @@ func TestExecGlob(t *testing.T) {
 		require.Contains(t, out, "c.go")
 		require.NotContains(t, out, "a.go")
 	})
+
+	t.Run("absolute path argument scopes the search to a subdirectory of the workdir", func(t *testing.T) {
+		out, isErr := execGlob(context.Background(), mustJSON(t, map[string]any{"pattern": "*.go", "path": filepath.Join(work, "sub")}), env)
+		require.False(t, isErr)
+		require.Contains(t, out, "c.go")
+		require.NotContains(t, out, "a.go")
+	})
 }
 
 func TestExecGrep(t *testing.T) {
@@ -103,10 +131,13 @@ func TestExecGrep(t *testing.T) {
 	env := &AgentToolContext{Workdir: work}
 	require.NoError(t, os.WriteFile(filepath.Join(work, "a.txt"), []byte("hello world\nfoo bar\nhello again"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(work, "b.txt"), []byte("nothing here"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(work, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(work, "sub", "c.txt"), []byte("hello sub"), 0o644))
 
 	tests := []struct {
 		description string
 		pattern     string
+		path        string
 		hidePath    bool
 		assert      func(t *testing.T, out string)
 		wantErr     bool
@@ -118,6 +149,15 @@ func TestExecGrep(t *testing.T) {
 				require.Contains(t, out, "a.txt:1:")
 				require.Contains(t, out, "a.txt:3:")
 				require.NotContains(t, out, "b.txt")
+			},
+		},
+		{
+			description: "absolute path argument scopes the search to a directory inside the workdir",
+			pattern:     "hello",
+			path:        filepath.Join(work, "sub"),
+			assert: func(t *testing.T, out string) {
+				require.Contains(t, out, "c.txt:1:")
+				require.NotContains(t, out, "a.txt")
 			},
 		},
 		{
@@ -140,6 +180,16 @@ func TestExecGrep(t *testing.T) {
 				require.Contains(t, out, "a.txt:1:")
 			},
 		},
+		{
+			description: "fallback walker accepts an absolute path argument inside the workdir",
+			pattern:     "hello",
+			path:        filepath.Join(work, "sub"),
+			hidePath:    true,
+			assert: func(t *testing.T, out string) {
+				require.Contains(t, out, "c.txt:1:")
+				require.NotContains(t, out, "a.txt")
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -147,7 +197,11 @@ func TestExecGrep(t *testing.T) {
 			if tc.hidePath {
 				t.Setenv("PATH", "")
 			}
-			out, isErr := execGrep(context.Background(), mustJSON(t, map[string]any{"pattern": tc.pattern}), env)
+			input := map[string]any{"pattern": tc.pattern}
+			if tc.path != "" {
+				input["path"] = tc.path
+			}
+			out, isErr := execGrep(context.Background(), mustJSON(t, input), env)
 			require.Equal(t, tc.wantErr, isErr, "output=%q", out)
 			if tc.assert != nil {
 				tc.assert(t, out)


### PR DESCRIPTION
## Summary
- Allow restricted agenttoolset file paths to use absolute paths when they canonicalize inside the configured workdir.
- Preserve workdir escape protection for outside paths, sibling-prefix paths, and symlinks that resolve outside the workdir.
- Extend the same behavior to glob/grep path arguments and confined absolute glob patterns.

Fixes #368

## Test Plan
- go test ./tools/agenttoolset -run 'TestResolvePath|TestExecGlob|TestExecGrep' -count=1 -v\n- go test ./tools/agenttoolset -count=1\n- go test ./tools/... -count=1\n- ./scripts/test -count=1\n- ./scripts/lint\n- git diff --check