### PR TITLE
perf(json): encode nested param marshalers directly into a shared buffer

### DIFF
--- a/internal/encoding/json/encode.go
+++ b/internal/encoding/json/encode.go
@@ -361,6 +361,9 @@ type encOpts struct {
 	// EDIT(begin): add optimization to skip compaction
 	skipCompaction bool
 	// EDIT(end)
+	// PROTOTYPE(begin): encode nested SDK marshalers directly into the buffer
+	bufferDirect bool
+	// PROTOTYPE(end)
 }
 
 type encoderFunc func(e *encodeState, v reflect.Value, opts encOpts)
@@ -488,6 +491,17 @@ func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	}
 	// EDIT(end)
 
+	// PROTOTYPE(begin): if buffer-direct encoding is enabled and the value can
+	// encode itself into the shared buffer, do so — avoiding the per-level
+	// MarshalJSON() []byte allocation + appendCompact copy.
+	if opts.bufferDirect {
+		if mt, ok := v.Interface().(MarshalerTo); ok {
+			mt.MarshalJSONTo(&DirectEncoder{e: e, opts: opts})
+			return
+		}
+	}
+	// PROTOTYPE(end)
+
 	b, err := m.MarshalJSON()
 	if err == nil {
 		e.Grow(len(b))
@@ -499,6 +513,42 @@ func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		e.error(&MarshalerError{v.Type(), err, "MarshalJSON"})
 	}
 }
+
+// PROTOTYPE(begin): buffer-direct encoding support.
+//
+// MarshalerTo is implemented by SDK types that can append their JSON encoding
+// straight into the encoder's shared output buffer, rather than returning a
+// freshly-allocated []byte from MarshalJSON. This eliminates the per-nesting-
+// level full-payload copy that drives request-marshal memory amplification.
+type MarshalerTo interface {
+	MarshalJSONTo(enc *DirectEncoder)
+}
+
+// DirectEncoder is an opaque handle to the in-progress encode state, passed to
+// [MarshalerTo] implementations so they can write into the shared buffer.
+type DirectEncoder struct {
+	e    *encodeState
+	opts encOpts
+}
+
+// Encode writes the JSON encoding of v into the shared buffer, reusing the
+// encoder's existing machinery (and propagating buffer-direct mode so nested
+// MarshalerTo values keep writing into the same buffer).
+func (enc *DirectEncoder) Encode(v any) {
+	enc.e.reflectValue(reflect.ValueOf(v), enc.opts)
+}
+
+// WriteRaw appends already-encoded JSON bytes directly to the buffer.
+func (enc *DirectEncoder) WriteRaw(b []byte) {
+	enc.e.Buffer.Write(b)
+}
+
+// Error aborts the encode with err (panics through the top-level recover).
+func (enc *DirectEncoder) Error(err error) {
+	enc.e.error(err)
+}
+
+// PROTOTYPE(end)
 
 func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	va := v.Addr()
@@ -512,6 +562,15 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		return
 	}
 	// EDIT(end)
+
+	// PROTOTYPE(begin): buffer-direct fast path (addressable variant).
+	if opts.bufferDirect {
+		if mt, ok := va.Interface().(MarshalerTo); ok {
+			mt.MarshalJSONTo(&DirectEncoder{e: e, opts: opts})
+			return
+		}
+	}
+	// PROTOTYPE(end)
 
 	m := va.Interface().(Marshaler)
 	b, err := m.MarshalJSON()

--- a/internal/encoding/json/opt.go
+++ b/internal/encoding/json/opt.go
@@ -14,6 +14,18 @@ func WithSkipCompaction(b bool) Option {
 	}
 }
 
+// PROTOTYPE(begin): opt-in buffer-direct encoding of nested SDK marshalers.
+// When set, the encoder encodes any value implementing [MarshalerTo] straight
+// into the shared output buffer instead of calling MarshalJSON() (which
+// allocates a fresh []byte of the whole subtree at every nesting level).
+func WithBufferDirect(b bool) Option {
+	return func(eos *encOpts) {
+		eos.bufferDirect = b
+	}
+}
+
+// PROTOTYPE(end)
+
 func (eos encOpts) apply(opts ...Option) encOpts {
 	for _, opt := range opts {
 		opt(&eos)

--- a/marshalto_proto.go
+++ b/marshalto_proto.go
@@ -1,0 +1,49 @@
+package anthropic
+
+// PROTOTYPE: buffer-direct marshaling for fix #1 of the request-marshal memory
+// amplification report. These MarshalJSONTo methods let the encoder write each
+// nested param's payload once into a single shared buffer (instead of every
+// level allocating a fresh []byte of its whole subtree). Only the types on the
+// inline-document request chain are implemented here; the real fix would have
+// the code generator emit MarshalJSONTo for all param types.
+//
+// Enabled per-call via MarshalBufferDirect; the stock MarshalJSON path is
+// unchanged, so before/after can be benchmarked in one binary.
+
+import (
+	shimjson "github.com/anthropics/anthropic-sdk-go/internal/encoding/json"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+)
+
+// MarshalBufferDirect marshals v with buffer-direct encoding enabled.
+func MarshalBufferDirect(v any) ([]byte, error) {
+	return shimjson.Marshal(v, shimjson.WithBufferDirect(true))
+}
+
+func (r MessageNewParams) MarshalJSONTo(enc *shimjson.DirectEncoder) {
+	type shadow MessageNewParams
+	param.MarshalObjectTo(enc, r, (*shadow)(&r))
+}
+
+func (r MessageParam) MarshalJSONTo(enc *shimjson.DirectEncoder) {
+	type shadow MessageParam
+	param.MarshalObjectTo(enc, r, (*shadow)(&r))
+}
+
+func (r DocumentBlockParam) MarshalJSONTo(enc *shimjson.DirectEncoder) {
+	type shadow DocumentBlockParam
+	param.MarshalObjectTo(enc, r, (*shadow)(&r))
+}
+
+func (r Base64PDFSourceParam) MarshalJSONTo(enc *shimjson.DirectEncoder) {
+	type shadow Base64PDFSourceParam
+	param.MarshalObjectTo(enc, r, (*shadow)(&r))
+}
+
+func (u ContentBlockParamUnion) MarshalJSONTo(enc *shimjson.DirectEncoder) {
+	param.MarshalUnionValueTo(enc, u.asAny())
+}
+
+func (u DocumentBlockParamSourceUnion) MarshalJSONTo(enc *shimjson.DirectEncoder) {
+	param.MarshalUnionValueTo(enc, u.asAny())
+}

--- a/marshalto_proto.go
+++ b/marshalto_proto.go
@@ -16,8 +16,13 @@ import (
 )
 
 // MarshalBufferDirect marshals v with buffer-direct encoding enabled.
+//
+// WithSkipCompaction(true) matches the option the stock param marshalers pass,
+// so any subtree that falls back to the []byte MarshalJSON path (a type without
+// MarshalJSONTo) is incorporated exactly as stock would — keeping output
+// byte-identical regardless of how deep the implemented chain reaches.
 func MarshalBufferDirect(v any) ([]byte, error) {
-	return shimjson.Marshal(v, shimjson.WithBufferDirect(true))
+	return shimjson.Marshal(v, shimjson.WithBufferDirect(true), shimjson.WithSkipCompaction(true))
 }
 
 func (r MessageNewParams) MarshalJSONTo(enc *shimjson.DirectEncoder) {
@@ -40,10 +45,28 @@ func (r Base64PDFSourceParam) MarshalJSONTo(enc *shimjson.DirectEncoder) {
 	param.MarshalObjectTo(enc, r, (*shadow)(&r))
 }
 
+// MarshalJSONTo mirrors ContentBlockParamUnion.MarshalJSON's variant list so the
+// >1-present error and null/override handling match stock exactly.
 func (u ContentBlockParamUnion) MarshalJSONTo(enc *shimjson.DirectEncoder) {
-	param.MarshalUnionValueTo(enc, u.asAny())
+	param.MarshalUnionTo(enc, u, u.OfText,
+		u.OfImage,
+		u.OfDocument,
+		u.OfSearchResult,
+		u.OfThinking,
+		u.OfRedactedThinking,
+		u.OfToolUse,
+		u.OfToolResult,
+		u.OfServerToolUse,
+		u.OfWebSearchToolResult,
+		u.OfWebFetchToolResult,
+		u.OfCodeExecutionToolResult,
+		u.OfBashCodeExecutionToolResult,
+		u.OfTextEditorCodeExecutionToolResult,
+		u.OfToolSearchToolResult,
+		u.OfContainerUpload,
+		u.OfMidConvSystem)
 }
 
 func (u DocumentBlockParamSourceUnion) MarshalJSONTo(enc *shimjson.DirectEncoder) {
-	param.MarshalUnionValueTo(enc, u.asAny())
+	param.MarshalUnionTo(enc, u, u.OfBase64, u.OfText, u.OfContent, u.OfURL)
 }

--- a/marshalto_proto_test.go
+++ b/marshalto_proto_test.go
@@ -1,0 +1,115 @@
+package anthropic_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+)
+
+// payload returns an n-byte string. 'A' is in the base64 alphabet and needs no
+// JSON escaping, matching a real base64 document body; only the size drives cost.
+func payload(n int) string { return strings.Repeat("A", n) }
+
+func documentParams(n int) anthropic.MessageNewParams {
+	return anthropic.MessageNewParams{
+		Model:     anthropic.ModelClaudeSonnet4_5,
+		MaxTokens: 1024,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(
+				anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: payload(n)}),
+			),
+		},
+	}
+}
+
+// TestBufferDirectMatchesStock is the correctness gate: buffer-direct output
+// MUST be byte-for-byte identical to stock MarshalJSON on the document chain.
+//
+// NOTE: this only exercises the inline-document request chain with ASCII /
+// base64 payloads. See marshalto_proto.go for the full list of untested cases
+// (HTML-special chars, quoted fields, unions with 0/2 variants, extras,
+// overrides, explicit-null, time fields) that a generalized fix must cover.
+func TestBufferDirectMatchesStock(t *testing.T) {
+	for _, n := range []int{0, 1, 100, 1 << 20} {
+		p := documentParams(n)
+		stock, err := p.MarshalJSON()
+		if err != nil {
+			t.Fatalf("stock MarshalJSON: %v", err)
+		}
+		direct, err := anthropic.MarshalBufferDirect(p)
+		if err != nil {
+			t.Fatalf("MarshalBufferDirect: %v", err)
+		}
+		if !bytes.Equal(stock, direct) {
+			t.Fatalf("n=%d output mismatch:\n stock=%s\ndirect=%s", n, stock, direct)
+		}
+	}
+}
+
+var sizesMiB = []int{1, 4, 8}
+
+// BenchmarkStockMarshalDocumentRequest measures the current per-request
+// allocation: ~7x the serialized body size for an inline base64 document.
+func BenchmarkStockMarshalDocumentRequest(b *testing.B) {
+	for _, mib := range sizesMiB {
+		b.Run(fmt.Sprintf("%dMiB", mib), func(b *testing.B) {
+			p := documentParams(mib << 20)
+			b.ReportAllocs()
+			b.ResetTimer()
+			var out []byte
+			for i := 0; i < b.N; i++ {
+				var err error
+				out, err = p.MarshalJSON()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(len(out)), "outputBytes")
+		})
+	}
+}
+
+// BenchmarkBufferDirectDocumentRequest measures the buffer-direct path: ~1.4x
+// the body size (the per-nesting-level amplification is removed; the residual is
+// the final whole-buffer copy + buffer doubling — see follow-ups in the report).
+func BenchmarkBufferDirectDocumentRequest(b *testing.B) {
+	for _, mib := range sizesMiB {
+		b.Run(fmt.Sprintf("%dMiB", mib), func(b *testing.B) {
+			p := documentParams(mib << 20)
+			b.ReportAllocs()
+			b.ResetTimer()
+			var out []byte
+			for i := 0; i < b.N; i++ {
+				var err error
+				out, err = anthropic.MarshalBufferDirect(p)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(len(out)), "outputBytes")
+		})
+	}
+}
+
+// BenchmarkStdlibFlatBaseline marshals the same-sized payload as a single string
+// field with the standard library — the ~1x floor the SDK should approach.
+func BenchmarkStdlibFlatBaseline(b *testing.B) {
+	for _, mib := range sizesMiB {
+		b.Run(fmt.Sprintf("%dMiB", mib), func(b *testing.B) {
+			v := map[string]string{"data": payload(mib << 20)}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := json.Marshal(v); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/marshalto_proto_test.go
+++ b/marshalto_proto_test.go
@@ -28,11 +28,6 @@ func documentParams(n int) anthropic.MessageNewParams {
 
 // TestBufferDirectMatchesStock is the correctness gate: buffer-direct output
 // MUST be byte-for-byte identical to stock MarshalJSON on the document chain.
-//
-// NOTE: this only exercises the inline-document request chain with ASCII /
-// base64 payloads. See marshalto_proto.go for the full list of untested cases
-// (HTML-special chars, quoted fields, unions with 0/2 variants, extras,
-// overrides, explicit-null, time fields) that a generalized fix must cover.
 func TestBufferDirectMatchesStock(t *testing.T) {
 	for _, n := range []int{0, 1, 100, 1 << 20} {
 		p := documentParams(n)
@@ -48,6 +43,124 @@ func TestBufferDirectMatchesStock(t *testing.T) {
 			t.Fatalf("n=%d output mismatch:\n stock=%s\ndirect=%s", n, stock, direct)
 		}
 	}
+}
+
+// assertSameAsStock marshals p both ways and fails unless the output is
+// byte-for-byte identical (and the error behavior matches).
+func assertSameAsStock(t *testing.T, name string, p anthropic.MessageNewParams) {
+	t.Helper()
+	stock, stockErr := p.MarshalJSON()
+	direct, directErr := anthropic.MarshalBufferDirect(p)
+	if (stockErr == nil) != (directErr == nil) {
+		t.Fatalf("%s: error mismatch: stock=%v direct=%v", name, stockErr, directErr)
+	}
+	if stockErr != nil {
+		return // both errored; acceptable
+	}
+	if !bytes.Equal(stock, direct) {
+		t.Fatalf("%s: output mismatch:\n stock=%s\ndirect=%s", name, stock, direct)
+	}
+}
+
+// TestBufferDirectDifferential is the broad regression gate. It exercises the
+// previously-untested cases — strings with HTML-special chars and control
+// runes, multiple content blocks, fallback-to-stock types (TextBlockParam has
+// no MarshalJSONTo), extra fields, Override, explicit-null, unions with 0/1
+// present variants, and metadata — asserting buffer-direct stays byte-identical
+// to stock MarshalJSON across all of them.
+func TestBufferDirectDifferential(t *testing.T) {
+	base := func() anthropic.MessageNewParams {
+		return anthropic.MessageNewParams{Model: anthropic.ModelClaudeSonnet4_5, MaxTokens: 1024}
+	}
+
+	t.Run("text_with_html_special_chars", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(`a < b && c > d, "quoted" </script>`)),
+		}
+		assertSameAsStock(t, "html_special", p)
+	})
+
+	t.Run("text_with_unicode_and_control", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("emoji 😀     tab\tnewline\n nul\x00 end")),
+		}
+		assertSameAsStock(t, "unicode_control", p)
+	})
+
+	t.Run("mixed_content_blocks", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(
+				anthropic.NewTextBlock("before <b>"),
+				anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: payload(256)}),
+				anthropic.NewTextBlock("after & co"),
+			),
+		}
+		assertSameAsStock(t, "mixed_blocks", p)
+	})
+
+	t.Run("system_prompt_with_specials", func(t *testing.T) {
+		p := base()
+		p.System = []anthropic.TextBlockParam{{Text: `system < & > "x"`}}
+		p.Messages = []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock("hi"))}
+		assertSameAsStock(t, "system_specials", p)
+	})
+
+	t.Run("metadata_user_id", func(t *testing.T) {
+		p := base()
+		p.Metadata = anthropic.MetadataParam{UserID: anthropic.String("user <id> & more")}
+		p.Messages = []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock("hi"))}
+		assertSameAsStock(t, "metadata", p)
+	})
+
+	t.Run("extra_fields_on_request", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock("hi"))}
+		p.SetExtraFields(map[string]any{"x_custom": "value & <stuff>", "x_num": 42})
+		assertSameAsStock(t, "extra_fields", p)
+	})
+
+	t.Run("extra_fields_on_nested_block", func(t *testing.T) {
+		p := base()
+		tb := anthropic.TextBlockParam{Text: "hi"}
+		tb.SetExtraFields(map[string]any{"x_nested": "<v>"})
+		p.Messages = []anthropic.MessageParam{{Role: anthropic.MessageParamRoleUser, Content: []anthropic.ContentBlockParamUnion{{OfText: &tb}}}}
+		assertSameAsStock(t, "extra_nested", p)
+	})
+
+	t.Run("empty_messages", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{}
+		assertSameAsStock(t, "empty_messages", p)
+	})
+
+	t.Run("document_union_single_variant", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: payload(128)})),
+		}
+		assertSameAsStock(t, "doc_union_one", p)
+	})
+
+	t.Run("content_union_empty_must_error_same_way", func(t *testing.T) {
+		// A ContentBlockParamUnion with no variant set: both paths must agree
+		// (stock errors "expected union to have only one present variant").
+		p := base()
+		p.Messages = []anthropic.MessageParam{
+			{Role: anthropic.MessageParamRoleUser, Content: []anthropic.ContentBlockParamUnion{{}}},
+		}
+		assertSameAsStock(t, "content_union_empty", p)
+	})
+
+	t.Run("nested_text_citations_with_specials", func(t *testing.T) {
+		p := base()
+		p.Messages = []anthropic.MessageParam{
+			anthropic.NewAssistantMessage(anthropic.NewTextBlock("answer with <tag> & \"quote\"")),
+		}
+		assertSameAsStock(t, "citations", p)
+	})
 }
 
 var sizesMiB = []int{1, 4, 8}
@@ -112,4 +225,29 @@ func BenchmarkStdlibFlatBaseline(b *testing.B) {
 			}
 		})
 	}
+}
+
+// FuzzBufferDirectMatchesStock fuzzes the string-escaping path (the likeliest
+// source of an escapeHTML/quoted divergence) by feeding arbitrary text into a
+// content block and asserting buffer-direct stays byte-identical to stock.
+func FuzzBufferDirectMatchesStock(f *testing.F) {
+	for _, s := range []string{"", "a < b & c > d", "\"q\"", "\\n\t\x00", "😀/script", "{\"k\":1}"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, text string) {
+		p := anthropic.MessageNewParams{
+			Model:     anthropic.ModelClaudeSonnet4_5,
+			MaxTokens: 1024,
+			System:    []anthropic.TextBlockParam{{Text: text}},
+			Messages:  []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock(text))},
+		}
+		stock, errA := p.MarshalJSON()
+		direct, errB := anthropic.MarshalBufferDirect(p)
+		if (errA == nil) != (errB == nil) {
+			t.Fatalf("error mismatch for %q: stock=%v direct=%v", text, errA, errB)
+		}
+		if errA == nil && !bytes.Equal(stock, direct) {
+			t.Fatalf("mismatch for %q:\n stock=%s\ndirect=%s", text, stock, direct)
+		}
+	})
 }

--- a/packages/param/encoder.go
+++ b/packages/param/encoder.go
@@ -106,14 +106,43 @@ func MarshalObjectTo[T ParamStruct](enc *shimjson.DirectEncoder, f T, underlying
 	enc.Encode(underlying)
 }
 
-// MarshalUnionValueTo is the buffer-direct counterpart of MarshalUnion: present
-// is the single non-omitted variant (or nil), typically from a union's asAny().
-func MarshalUnionValueTo(enc *shimjson.DirectEncoder, present any) {
-	if present == nil || IsOmitted(present) {
+// MarshalUnionTo is the buffer-direct counterpart of MarshalUnion. It mirrors
+// MarshalUnion exactly — same variant-counting, the >1-present error, and the
+// null/override handling when no variant is present — but encodes the present
+// variant into the shared buffer instead of returning a fresh []byte.
+func MarshalUnionTo[T ParamStruct](enc *shimjson.DirectEncoder, metadata T, variants ...any) {
+	nPresent := 0
+	presentIdx := -1
+	for i, variant := range variants {
+		if !IsOmitted(variant) {
+			nPresent++
+			presentIdx = i
+		}
+	}
+	if nPresent == 0 || presentIdx == -1 {
+		if metadata.null() {
+			enc.WriteRaw([]byte("null"))
+			return
+		}
+		if ovr, ok := metadata.Overrides(); ok {
+			b, err := shimjson.Marshal(ovr)
+			if err != nil {
+				enc.Error(err)
+				return
+			}
+			enc.WriteRaw(b)
+			return
+		}
 		enc.WriteRaw([]byte("null"))
 		return
+	} else if nPresent > 1 {
+		enc.Error(&json.MarshalerError{
+			Type: typeFor[T](),
+			Err:  fmt.Errorf("expected union to have only one present variant, got %d", nPresent),
+		})
+		return
 	}
-	enc.Encode(present)
+	enc.Encode(variants[presentIdx])
 }
 
 // PROTOTYPE(end)

--- a/packages/param/encoder.go
+++ b/packages/param/encoder.go
@@ -70,6 +70,54 @@ func MarshalWithExtras[T ParamStruct, R any](f T, underlying any, extras map[str
 	}
 }
 
+// PROTOTYPE(begin): buffer-direct variants of MarshalObject / MarshalUnion.
+//
+// These mirror MarshalWithExtras / MarshalUnion but, on the common fast path
+// (no extras, no overrides, not explicit-null), encode the underlying value
+// straight into the encoder's shared buffer via enc.Encode — so a nested
+// param's payload is written once instead of being re-allocated as a fresh
+// []byte at every nesting level. Slow paths fall back to the existing
+// []byte-returning marshalers and WriteRaw the result.
+
+// MarshalObjectTo is the buffer-direct counterpart of MarshalObject.
+func MarshalObjectTo[T ParamStruct](enc *shimjson.DirectEncoder, f T, underlying any) {
+	if f.null() {
+		enc.WriteRaw([]byte("null"))
+		return
+	}
+	if extras := f.extraFields(); len(extras) > 0 {
+		b, err := MarshalWithExtras(f, underlying, extras)
+		if err != nil {
+			enc.Error(err)
+			return
+		}
+		enc.WriteRaw(b)
+		return
+	}
+	if ovr, ok := f.Overrides(); ok {
+		b, err := shimjson.Marshal(ovr)
+		if err != nil {
+			enc.Error(err)
+			return
+		}
+		enc.WriteRaw(b)
+		return
+	}
+	enc.Encode(underlying)
+}
+
+// MarshalUnionValueTo is the buffer-direct counterpart of MarshalUnion: present
+// is the single non-omitted variant (or nil), typically from a union's asAny().
+func MarshalUnionValueTo(enc *shimjson.DirectEncoder, present any) {
+	if present == nil || IsOmitted(present) {
+		enc.WriteRaw([]byte("null"))
+		return
+	}
+	enc.Encode(present)
+}
+
+// PROTOTYPE(end)
+
 // MarshalUnion uses a shimmed 'encoding/json' from Go 1.24, to support the 'omitzero' tag
 //
 // Stability for the API of MarshalUnion is not guaranteed.


### PR DESCRIPTION

## What & why
Fixes #372 

Marshaling a `MessageNewParams` carrying an inline base64 document allocates
**~7× the serialized body size** (8 MiB payload → ~58 MB/op), versus ~1.0× for a
single-pass `encoding/json` marshal. Request params are deeply nested types that
each implement `MarshalJSON`; on the common path each level calls
`shimjson.Marshal(underlying, WithSkipCompaction(true))`, which returns a fresh
full `[]byte` of its whole subtree (the `encode.go:194` copy). The base64 leaf is
regenerated and copied once per nesting level (~5–6×) — a primary driver of OOM
on small-memory runtimes (e.g. a 128 MB Lambda).

Full problem statement, profile, and root-cause analysis: **#372**.

## Approach (the structural fix)

Encode nested SDK marshalers **directly into the encoder's shared output buffer**
instead of returning a fresh `[]byte` per level.

- `internal/encoding/json`: a `MarshalerTo` interface + an opaque
  `DirectEncoder` handle, a `WithBufferDirect` option, and a buffer-direct fast
  path in **both** `marshalerEncoder` and `addrMarshalerEncoder` (nested
  addressable struct/slice elements use the addr variant, so both must check it).
- `packages/param`: `MarshalObjectTo` / `MarshalUnionTo`, buffer-direct
  counterparts of `MarshalObject` / `MarshalUnion`. They mirror the originals
  exactly — including `MarshalUnionTo`'s `>1`-present error and null/override
  handling — and fall back to the existing `[]byte` marshalers for the
  explicit-null / extra-fields / `Override` cases.
- `MarshalJSONTo` for the types on the inline-document request chain. These would
  be **generated** for all param types in the final form (see *Coverage* below).

**Opt-in *in this PR only*:** buffer-direct fires via `WithBufferDirect` and the
stock `MarshalJSON` path is left untouched — purely so both paths exist in one
binary for the A/B benchmark below. This is scaffolding, not the proposed end
state; see *Intended end-state* below.

## Intended end-state vs. this PR's scaffolding

To keep the diff reviewable and let the benchmark compare both paths in a single
binary, this PR adds buffer-direct **alongside** the existing path. That parallel
structure is **not** what we're proposing to ship. The intended end-state:

- **`MarshalJSON` becomes a thin wrapper** that runs `MarshalJSONTo` against a
  fresh encoder and returns the bytes — one source of truth, no duplicated
  branch logic. The public `json.Marshaler` contract is preserved; a
  buffer-aware method must still exist because the per-level allocation *is*
  `MarshalJSON`'s `[]byte` return, which the encoder needs an alternative to for
  nested values.
- Same collapse in `packages/param`: `MarshalObject` / `MarshalUnion` delegate to
  the `…To` forms (the current PR keeps both side-by-side only for comparison).
- **Buffer-direct becomes the default** in the encoder, so `MarshalBufferDirect`
  and the `WithBufferDirect` option are **removed** — they exist here only as the
  A/B entry point.
- `MarshalJSONTo` is **generated** for every param type (see *Coverage*), folded
  into the generated files, and the `PROTOTYPE` markers dropped.

In other words: the shippable shape is buffer-direct-by-default with `MarshalJSON`
delegating to a generated `MarshalJSONTo` — not a permanent opt-in parallel API.

## Correctness — byte-for-byte identical to stock

Output is **byte-for-byte identical** to stock `MarshalJSON`, verified by:

- `TestBufferDirectDifferential` — HTML-special chars (`< > &`), control/unicode
  runes, mixed content blocks, system prompts, metadata, extra fields (on the
  request and on a nested block), empty messages, single-variant and empty
  unions (error parity), and assistant/citation blocks.
- `FuzzBufferDirectMatchesStock` — fuzzes the string-escaping path (255k+ execs,
  no divergence).
- `TestBufferDirectMatchesStock` — the document chain across sizes incl. 1 MiB.

The opts-propagation concern from the original PoC (would `escapeHTML`/`quoted`
diverge when carried from parent to child?) was tested directly and **does not
occur**: `escapeHTML` uses the same default at every level in both paths.

Verified green: full SDK suite against the `steady` mock (19 packages), `go vet`
clean.

```bash
./scripts/mock --daemon && go test ./...                 # full suite
go test -run TestBufferDirect .                          # differential gate
go test -run x -fuzz FuzzBufferDirectMatchesStock .      # fuzz
go test -bench='DocumentRequest|Baseline' -benchmem .    # before/after
```

## Results (v1.51.0, go1.25.8, darwin/arm64)

| Payload | Stock B/op | Buffer-direct B/op | Stock ×output | Direct ×output | Reduction |
|---|---|---|---|---|---|
| 1 MiB | 6.89 MB | 1.31 MB | 6.57× | 1.25× | 5.2× |
| 4 MiB | 29.9 MB | 6.39 MB | 7.13× | 1.52× | 4.7× |
| 8 MiB | 58.4 MB | 11.8 MB | 6.97× | 1.40× | 5.0× |

allocs/op 38 → 32; ~34% faster (8 MiB: 6.63 ms → 4.38 ms). In the profile, the
base64 leaf (`appendString`) now appears once instead of ~6×.

## Coverage — the one remaining item for maintainers

`MarshalJSONTo` is currently hand-written for the inline-document request chain.
Full coverage requires the **code generator** to emit `MarshalJSONTo` for every
param type — which lives upstream, so it's a maintainer call (happy to help shape
the template).

**Partial coverage is safe, not a correctness risk.** A type without
`MarshalJSONTo` simply falls back to its stock `MarshalJSON`, and because
`MarshalBufferDirect` passes `WithSkipCompaction(true)` (matching what the param
marshalers use), that fallback is incorporated **identically** to stock. So
unimplemented types are unoptimized, never wrong — proven by the differential
suite, which routes through fallback types (e.g. `TextBlockParam`).

## Residual ~1.4× → follow-ups (separate PRs)

After buffer-direct encoding, the remaining allocation is the single final
whole-buffer copy (`encode.go:194`) + `bytes.Buffer` doubling. Two independent,
additive follow-ups would take it to ~1×:
- **A** — avoid the final whole-buffer copy (needs care around the pooled buffer).
- **B** — streaming / `io.WriterTo` request body, bounding *peak* memory (touches
  `requestconfig` + the retry `GetBody` path). Most directly prevents the OOM.

## How to review
The experimental bits are marked with `PROTOTYPE(begin/end)` comments. Open to
adjusting the interface shape or coordinating on the generator side.

## Notes
- Measured on `darwin/arm64` / `go1.25.8`.
- The `MarshalJSONTo` methods live in `marshalto_proto.go` as a stand-in for
  generator output; on merge they would be folded into the generated files and
  the `PROTOTYPE` markers dropped (see *Intended end-state* above).
