### PR TITLE
fix(auth): skip env auth when credentials are explicit

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,16 +46,24 @@ type Client struct {
 // When no source produces a credential, the first request fails with an
 // [auth.NoCredentialsError]. If ANTHROPIC_PROFILE points at a missing or
 // invalid profile, the first request instead fails with a wrapped
-// profile-load error naming the profile. An explicit credential option
-// passed to [NewClient] (e.g. [option.WithAPIKey] or [option.WithAuthToken])
-// suppresses both paths. Also honors ANTHROPIC_BASE_URL.
+// profile-load error naming the profile. When called by [NewClient], an
+// explicit credential option (e.g. [option.WithAPIKey] or
+// [option.WithAuthToken]) suppresses credential autoload. Also honors
+// ANTHROPIC_BASE_URL.
 func DefaultClientOptions() []option.RequestOption {
+	return defaultClientOptions(true)
+}
+
+func defaultClientOptions(loadCredentials bool) []option.RequestOption {
 	defaults := []option.RequestOption{
 		option.WithHTTPClient(defaultHTTPClient()),
 		option.WithEnvironmentProduction(),
 	}
 	if o, ok := os.LookupEnv("ANTHROPIC_BASE_URL"); ok {
 		defaults = append(defaults, option.WithBaseURL(o))
+	}
+	if !loadCredentials {
+		return appendNonCredentialEnvOptions(defaults)
 	}
 
 	statuses := []auth.CredentialSourceStatus{}
@@ -110,6 +118,14 @@ func DefaultClientOptions() []option.RequestOption {
 	if fallbackOpt != nil {
 		return append(defaults, fallbackOpt)
 	}
+	defaults = appendNonCredentialEnvOptions(defaults)
+
+	statuses = append(statuses, envFederationStatus, fallbackStatus)
+	defaults = append(defaults, noCredentialsSentinel(statuses))
+	return defaults
+}
+
+func appendNonCredentialEnvOptions(defaults []option.RequestOption) []option.RequestOption {
 	if o, ok := os.LookupEnv("ANTHROPIC_WEBHOOK_SIGNING_KEY"); ok {
 		defaults = append(defaults, option.WithWebhookKey(o))
 	}
@@ -121,9 +137,6 @@ func DefaultClientOptions() []option.RequestOption {
 			}
 		}
 	}
-
-	statuses = append(statuses, envFederationStatus, fallbackStatus)
-	defaults = append(defaults, noCredentialsSentinel(statuses))
 	return defaults
 }
 
@@ -208,6 +221,8 @@ func NewClient(opts ...option.RequestOption) (r Client) {
 	var defaults []option.RequestOption
 	if option.HasWithoutEnvironmentDefaults(opts) {
 		defaults = []option.RequestOption{option.WithEnvironmentProduction()}
+	} else if option.HasExplicitCredential(opts) {
+		defaults = defaultClientOptions(false)
 	} else {
 		defaults = DefaultClientOptions()
 	}

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -1336,6 +1336,62 @@ func TestDefaultClient_ExplicitAuthTokenOverridesBrokenProfile(t *testing.T) {
 	}
 }
 
+func TestDefaultClient_ExplicitAuthTokenSkipsEnvAPIKey(t *testing.T) {
+	unsetEnv(t, "ANTHROPIC_AUTH_TOKEN")
+	isolateAuthEnv(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-env-key")
+
+	var receivedHeaders http.Header
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(successResponse))
+	}))
+	defer apiServer.Close()
+
+	client := anthropic.NewClient(
+		option.WithBaseURL(apiServer.URL),
+		option.WithAuthToken("tok-explicit"),
+	)
+	_, err := client.Messages.New(context.Background(), defaultParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := receivedHeaders.Get("Authorization"); got != "Bearer tok-explicit" {
+		t.Fatalf("Authorization: got %q, want %q", got, "Bearer tok-explicit")
+	}
+	if got := receivedHeaders.Get("X-Api-Key"); got != "" {
+		t.Fatalf("X-Api-Key should not be sent when explicit auth token is passed, got %q", got)
+	}
+}
+
+func TestDefaultClient_ExplicitAPIKeySkipsEnvAuthToken(t *testing.T) {
+	unsetEnv(t, "ANTHROPIC_API_KEY")
+	isolateAuthEnv(t)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "tok-env")
+
+	var receivedHeaders http.Header
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(successResponse))
+	}))
+	defer apiServer.Close()
+	t.Setenv("ANTHROPIC_BASE_URL", apiServer.URL)
+
+	client := anthropic.NewClient(option.WithAPIKey("sk-explicit"))
+	_, err := client.Messages.New(context.Background(), defaultParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := receivedHeaders.Get("X-Api-Key"); got != "sk-explicit" {
+		t.Fatalf("X-Api-Key: got %q, want %q", got, "sk-explicit")
+	}
+	if got := receivedHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization should not be sent when explicit API key is passed, got %q", got)
+	}
+}
+
 // TestIntegration_APIKeyShadowWarning_InvertedOrder locks in that the
 // shadow warning fires regardless of the order the caller passes
 // option.WithConfig and option.WithAPIKey. The earlier implementation

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -601,20 +601,49 @@ func WithEnvironmentProduction() RequestOption {
 	return requestconfig.WithDefaultBaseURL("https://api.anthropic.com/")
 }
 
+type staticCredentialOption interface {
+	RequestOption
+	isStaticCredentialOption()
+}
+
+type apiKeyOption string
+
+func (apiKeyOption) isStaticCredentialOption() {}
+
+func (o apiKeyOption) Apply(r *requestconfig.RequestConfig) error {
+	r.APIKey = string(o)
+	return r.Apply(WithHeader("X-Api-Key", r.APIKey))
+}
+
+type authTokenOption string
+
+func (authTokenOption) isStaticCredentialOption() {}
+
+func (o authTokenOption) Apply(r *requestconfig.RequestConfig) error {
+	r.AuthToken = string(o)
+	return r.Apply(WithHeader("authorization", fmt.Sprintf("Bearer %s", r.AuthToken)))
+}
+
+// HasExplicitCredential reports whether opts contains a caller-supplied
+// static credential. NewClient uses this to avoid prepending credential
+// autoload options from the environment or profile config.
+func HasExplicitCredential(opts []RequestOption) bool {
+	for _, o := range opts {
+		if _, ok := o.(staticCredentialOption); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // WithAPIKey returns a RequestOption that sets the client setting "api_key".
 func WithAPIKey(value string) RequestOption {
-	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		r.APIKey = value
-		return r.Apply(WithHeader("X-Api-Key", r.APIKey))
-	})
+	return apiKeyOption(value)
 }
 
 // WithAuthToken returns a RequestOption that sets the client setting "auth_token".
 func WithAuthToken(value string) RequestOption {
-	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
-		r.AuthToken = value
-		return r.Apply(WithHeader("authorization", fmt.Sprintf("Bearer %s", r.AuthToken)))
-	})
+	return authTokenOption(value)
 }
 
 // WithWebhookKey returns a RequestOption that sets the client setting "webhook_key".


### PR DESCRIPTION
Fixes #364.

## Summary
- detect caller-supplied `option.WithAPIKey` / `option.WithAuthToken` in `NewClient`
- skip env/profile/federation credential autoload when a static credential is explicit
- preserve non-credential defaults such as `ANTHROPIC_BASE_URL`
- add integration coverage for env API key + explicit auth token and env auth token + explicit API key

## Tests
- `go test ./internal/auth -run 'TestDefaultClient_Explicit(AuthTokenSkipsEnvAPIKey|APIKeySkipsEnvAuthToken)' -count=1 -v`
- `go test ./internal/auth -count=1`
- `./scripts/test -count=1`
- `./scripts/lint`
- `git diff --check`
