### PR TITLE
ci: pin GitHub Actions to full commit SHAs in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
## Summary

Pins all GitHub Actions to full immutable commit SHAs instead of mutable version tags.

## Vulnerability

Mutable tags (`@v1`, `@v3`, `@v4`, etc.) can be silently updated — a compromised action repository could deliver malicious code into CI with access to secrets and write permissions. This is the same attack class as the [tj-actions/changed-files supply chain incident (March 2025)](https://www.bleepingcomputer.com/news/security/popular-github-action-tjactionschanged-files-compromised-in-supply-chain-attack/).

## Change

All `uses: action@vX` references replaced with `uses: action@<full-sha> # vX`. No behaviour change — pins point to the exact same code as the current tags.

## References
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

## Actions pinned
| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | `v4` | `34e1148` |
| `anthropics/claude-code-action` | `v1` | `a92e7c7` |