### PR TITLE
fix(agenttoolset): guard empty tool results

### DIFF
--- a/tools/agenttoolset/agenttoolset.go
+++ b/tools/agenttoolset/agenttoolset.go
@@ -141,8 +141,13 @@ func (t *funcTool) Execute(ctx context.Context, input json.RawMessage) ([]anthro
 	return textResult(content), nil
 }
 
+const emptyToolOutputText = "(no output)"
+
 // textResult wraps a plain string as a single text tool-result block.
 func textResult(s string) []anthropic.BetaToolResultBlockParamContentUnion {
+	if s == "" {
+		s = emptyToolOutputText
+	}
 	return []anthropic.BetaToolResultBlockParamContentUnion{{OfText: &anthropic.BetaTextBlockParam{Text: s}}}
 }
 

--- a/tools/agenttoolset/agenttoolset_test.go
+++ b/tools/agenttoolset/agenttoolset_test.go
@@ -152,6 +152,13 @@ func TestBetaAgentToolset(t *testing.T) {
 	}
 }
 
+func TestTextResultUsesNonEmptyPlaceholderForEmptyOutput(t *testing.T) {
+	got := textResult("")
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].OfText)
+	require.Equal(t, "(no output)", got[0].OfText.Text)
+}
+
 // closerTool is a BetaTool whose Close behaviour is controlled by onClose. Used
 // to verify CloseAll's per-tool isolation.
 type closerTool struct {


### PR DESCRIPTION
Fixes #377.

Problem:
A successful agent tool can produce no output. The environment worker then sends a tool_result text block with an empty string, which the API rejects because text blocks must be non-empty. That can leave self-hosted worker sessions stuck after commands such as mkdir, touch, cd, or grep -q.

Root cause:
tools/agenttoolset.textResult wrapped the successful output string verbatim, including the empty string.

Change:
Normalize empty successful tool output to the non-empty placeholder `(no output)` before building the text result block. Non-empty output is unchanged.

Verification:
- go test ./tools/agenttoolset

Also tried `go test ./...`; the root package tests failed because this local environment does not have the expected mock API server on localhost:4010 running. The changed package passed.