### PR TITLE
fix(agenttoolset): guard empty tool results

### DIFF
--- a/tools/agenttoolset/agenttoolset.go
+++ b/tools/agenttoolset/agenttoolset.go
@@ -141,8 +141,13 @@ func (t *funcTool) Execute(ctx context.Context, input json.RawMessage) ([]anthro
 	return textResult(content), nil
 }
 
+const emptyToolOutputText = "(no output)"
+
 // textResult wraps a plain string as a single text tool-result block.
 func textResult(s string) []anthropic.BetaToolResultBlockParamContentUnion {
+	if s == "" {
+		s = emptyToolOutputText
+	}
 	return []anthropic.BetaToolResultBlockParamContentUnion{{OfText: &anthropic.BetaTextBlockParam{Text: s}}}
 }
 

--- a/tools/agenttoolset/agenttoolset_test.go
+++ b/tools/agenttoolset/agenttoolset_test.go
@@ -152,6 +152,13 @@ func TestBetaAgentToolset(t *testing.T) {
 	}
 }
 
+func TestTextResultUsesNonEmptyPlaceholderForEmptyOutput(t *testing.T) {
+	got := textResult("")
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].OfText)
+	require.Equal(t, "(no output)", got[0].OfText.Text)
+}
+
 // closerTool is a BetaTool whose Close behaviour is controlled by onClose. Used
 // to verify CloseAll's per-tool isolation.
 type closerTool struct {


### PR DESCRIPTION
Fixes #377.

## Summary

- replace an empty successful agent-tool output with `(no output)` before constructing the text result block
- leave non-empty tool output unchanged
- add a regression test for the empty-output case

The API requires text blocks to contain at least one character. Without this guard, commands that succeed silently produce a `user.tool_result` with `text: ""`, receive a 400 response, and can leave a self-hosted worker session stuck.

This intentionally overlaps with #387. It is the same small fix that we have independently tested in a downstream self-hosted worker image; either PR can resolve #377.

## Verification

- `go test -count=1 ./tools/agenttoolset`
- `./scripts/lint`
- `go vet . ./tools/agenttoolset`
