### PR TITLE
fix(sessions): settle interrupted tool calls

### DIFF
--- a/betasessiontoolrunner.go
+++ b/betasessiontoolrunner.go
@@ -279,15 +279,22 @@ type SessionToolRunner struct {
 	// Tracks in-flight tool executions for the drain phase.
 	inFlight sync.WaitGroup
 
-	// Dedup sets — touched by the stream goroutine, the reconcile pass before
-	// each stream reconnect, and the dispatch goroutine. `seen` prevents
-	// re-dispatching the same tool_use across reconcile+stream overlaps;
-	// `answered` prevents re-executing a tool whose result the server already
-	// has. One mutex covers both — they're always touched together at low
-	// frequency.
-	mu       sync.Mutex
-	seen     map[string]struct{}
-	answered map[string]struct{}
+	// eventMu serializes idle/settlement transitions from the stream/reconcile
+	// goroutine with the dispatch-side history refresh after a rejected result.
+	eventMu sync.Mutex
+
+	// Tool-call state shared by the stream/reconcile and dispatch goroutines.
+	// `seen` stores each call's processed timestamp for stream/history dedup and
+	// interrupt cutoff checks; `answered` tracks results accepted by the server;
+	// `canceled` tracks calls invalidated by a processed session-wide interrupt.
+	// The active-call fields let such an interrupt cancel local execution too.
+	mu                      sync.Mutex
+	seen                    map[string]time.Time
+	answered                map[string]struct{}
+	canceled                map[string]struct{}
+	latestGlobalInterruptAt time.Time
+	activeCallID            string
+	activeCallCancel        context.CancelFunc
 	// Confirmation gating (always_ask tools). `confirmationVerdicts` records
 	// every user.tool_confirmation verdict by tool_use_id (persistent for the
 	// run, like seen/answered). `awaitingConfirmation` holds the ask-gated tool
@@ -351,8 +358,9 @@ func (r *BetaSessionEventService) NewToolRunner(ctx context.Context, sessionID s
 		reqOpts:      reqOpts,
 		ctx:          internalCtx,
 		cancel:       cancel,
-		seen:         map[string]struct{}{},
+		seen:         map[string]time.Time{},
 		answered:     map[string]struct{}{},
+		canceled:     map[string]struct{}{},
 	}
 	rn.confirmationVerdicts = map[string]string{}
 	rn.awaitingConfirmation = map[string]pendingToolUse{}
@@ -379,15 +387,37 @@ func (r *SessionToolRunner) Next() bool {
 		return false
 	}
 	r.start()
+	// Prefer already-buffered calls over cancellation so a terminal error does
+	// not hide the rejected dispatch that produced it.
 	select {
-	case <-r.ctx.Done():
-		return false
 	case call, ok := <-r.results:
 		if !ok {
 			return false
 		}
 		r.current = call
 		return true
+	default:
+	}
+	select {
+	case call, ok := <-r.results:
+		if !ok {
+			return false
+		}
+		r.current = call
+		return true
+	case <-r.ctx.Done():
+		// coordinate may have canceled the context after buffering the final
+		// call. Check once more before ending iteration.
+		select {
+		case call, ok := <-r.results:
+			if !ok {
+				return false
+			}
+			r.current = call
+			return true
+		default:
+			return false
+		}
 	}
 }
 
@@ -737,22 +767,28 @@ func (r *SessionToolRunner) streamLoop(ctx context.Context, out chan<- pendingTo
 				backoff = sessionRunnerStreamBackoffStart
 			}
 			ev := stream.Current()
+			r.eventMu.Lock()
 			r.idle.noteEvent(ev.Type, ev.StopReason.Type)
 			switch ev.Type {
+			case "user.interrupt":
+				r.processGlobalInterrupt(ev.ProcessedAt, ev.SessionThreadID)
+			case string(BetaManagedAgentsUserToolResultEventTypeUserToolResult):
+				r.noteAnswered(ev.ToolUseID)
+			case string(BetaManagedAgentsUserCustomToolResultEventTypeUserCustomToolResult):
+				r.noteAnswered(ev.CustomToolUseID)
+			}
+			r.eventMu.Unlock()
+			switch ev.Type {
 			case string(BetaManagedAgentsAgentToolUseEventTypeAgentToolUse):
-				if r.markSeen(ev.ID) {
+				if r.markSeen(ev.ID, ev.ProcessedAt) {
 					r.routeToolEvent(ctx, out, pendingToolUse{toolUse: ev.AsAgentToolUse()})
 				}
 			case string(BetaManagedAgentsAgentCustomToolUseEventTypeAgentCustomToolUse):
-				if r.markSeen(ev.ID) {
+				if r.markSeen(ev.ID, ev.ProcessedAt) {
 					r.routeToolEvent(ctx, out, pendingToolUse{custom: true, customToolUse: ev.AsAgentCustomToolUse()})
 				}
 			case "user.tool_confirmation":
 				r.noteConfirmation(ctx, out, ev.ToolUseID, string(ev.Result))
-			case string(BetaManagedAgentsUserToolResultEventTypeUserToolResult):
-				r.markAnswered(ev.ToolUseID)
-			case string(BetaManagedAgentsUserCustomToolResultEventTypeUserCustomToolResult):
-				r.markAnswered(ev.CustomToolUseID)
 			case string(BetaManagedAgentsSessionStatusTerminatedEventTypeSessionStatusTerminated),
 				string(BetaManagedAgentsSessionDeletedEventTypeSessionDeleted):
 				r.log.Info("session terminated", slog.String("type", ev.Type))
@@ -804,15 +840,21 @@ func jitterDuration(d time.Duration) time.Duration {
 //
 // Every tool-use event is collected — and marked seen so the concurrently
 // running stream loop does not also enqueue it — but the enqueue decision is
-// gated on `answered`, NOT `seen`: a tool_use whose result post previously
-// FAILED was never marked answered, so it is re-dispatched on the next
-// reconcile instead of being silently dropped.
+// gated on whether the call is settled, NOT merely seen. Calls canceled by a
+// processed session-wide interrupt are settled locally because the server no
+// longer accepts their results; transient send failures remain eligible for a
+// later reconcile.
 //
 // Returns ErrSessionTerminated if the listed history contains a
 // session.status_terminated or session.deleted event — the live stream
 // will never replay a terminate that fired before we attached, so without
 // this check streamLoop would reconnect forever against a dead session.
 func (r *SessionToolRunner) reconcile(ctx context.Context, out chan<- pendingToolUse) error {
+	// Reconciliation replaces the runner's view of session idleness. Clear any
+	// prior pending arm before interrupts/results retire confirmation blockers.
+	r.eventMu.Lock()
+	r.idle.disarm()
+	r.eventMu.Unlock()
 	var pending []pendingToolUse
 	lastWasEndTurn := false
 	pager := r.eventService.ListAutoPaging(ctx, r.sessionID,
@@ -826,23 +868,34 @@ func (r *SessionToolRunner) reconcile(ctx context.Context, out chan<- pendingToo
 		ev := pager.Current()
 		switch ev.Type {
 		case string(BetaManagedAgentsAgentToolUseEventTypeAgentToolUse):
-			r.markSeen(ev.ID)
+			r.markSeen(ev.ID, ev.ProcessedAt)
 			pending = append(pending, pendingToolUse{toolUse: ev.AsAgentToolUse()})
 		case string(BetaManagedAgentsAgentCustomToolUseEventTypeAgentCustomToolUse):
-			r.markSeen(ev.ID)
+			r.markSeen(ev.ID, ev.ProcessedAt)
 			pending = append(pending, pendingToolUse{custom: true, customToolUse: ev.AsAgentCustomToolUse()})
 		case "user.tool_confirmation":
 			// Record the verdict only, before the routing pass below, so a
 			// tool call whose confirmation appears later in the same history
-			// is routed with its verdict already known. Skip already-answered
-			// calls so we don't re-record their verdict on every reconcile.
-			if !r.isAnswered(ev.ToolUseID) {
+			// is routed with its verdict already known. Skip settled calls so
+			// we don't re-record their verdict on every reconcile.
+			if !r.isSettled(ev.ToolUseID) {
 				r.confirmationVerdicts[ev.ToolUseID] = string(ev.Result)
 			}
+		case "user.interrupt":
+			// Event history is ordered by created_at, which can differ from
+			// processed_at for queued user events. Keep a processed-time cutoff
+			// instead of assuming every later history entry survived the interrupt.
+			r.eventMu.Lock()
+			r.processGlobalInterrupt(ev.ProcessedAt, ev.SessionThreadID)
+			r.eventMu.Unlock()
 		case string(BetaManagedAgentsUserToolResultEventTypeUserToolResult):
-			r.markAnswered(ev.ToolUseID)
+			r.eventMu.Lock()
+			r.noteAnswered(ev.ToolUseID)
+			r.eventMu.Unlock()
 		case string(BetaManagedAgentsUserCustomToolResultEventTypeUserCustomToolResult):
-			r.markAnswered(ev.CustomToolUseID)
+			r.eventMu.Lock()
+			r.noteAnswered(ev.CustomToolUseID)
+			r.eventMu.Unlock()
 		case string(BetaManagedAgentsSessionStatusTerminatedEventTypeSessionStatusTerminated),
 			string(BetaManagedAgentsSessionDeletedEventTypeSessionDeleted):
 			// The session is already over. Any pending tool_use we
@@ -861,13 +914,10 @@ func (r *SessionToolRunner) reconcile(ctx context.Context, out chan<- pendingToo
 	}
 	var unanswered []pendingToolUse
 	for _, p := range pending {
-		if !r.isAnswered(p.id()) {
+		if !r.isSettled(p.id()) {
 			unanswered = append(unanswered, p)
 		}
 	}
-	// Disarm before routing: the routing pass can block on a full work queue
-	// while the clock is still armed from before the reconnect.
-	r.idle.disarm()
 	for _, p := range unanswered {
 		r.routeToolEvent(ctx, out, p)
 	}
@@ -875,6 +925,10 @@ func (r *SessionToolRunner) reconcile(ctx context.Context, out chan<- pendingToo
 	// its tool_use fell outside the listed window the pass never saw it, so
 	// apply the recorded verdict to the held copy here.
 	for id, held := range r.awaitingConfirmation {
+		if r.isSettled(id) {
+			r.cancelHeldCall(id)
+			continue
+		}
 		if v, ok := r.confirmationVerdicts[id]; ok {
 			r.applyVerdict(ctx, out, held, v)
 		}
@@ -886,7 +940,9 @@ func (r *SessionToolRunner) reconcile(ctx context.Context, out chan<- pendingToo
 	// during a disconnect. A still-held call doesn't count as outstanding: the
 	// clock blocks on it, so the arm is held pending until its verdict lands.
 	if lastWasEndTurn && len(r.outstanding(unanswered)) == 0 {
+		r.eventMu.Lock()
 		r.idle.arm()
+		r.eventMu.Unlock()
 	}
 	return nil
 }
@@ -901,7 +957,7 @@ func (r *SessionToolRunner) outstanding(unanswered []pendingToolUse) []pendingTo
 		if _, held := r.awaitingConfirmation[id]; held {
 			continue
 		}
-		if r.isAnswered(id) {
+		if r.isSettled(id) {
 			continue
 		}
 		out = append(out, p)
@@ -931,13 +987,19 @@ func (r *SessionToolRunner) dispatchLoop(ctx context.Context, in <-chan pendingT
 			// executed and surfaced, or moot because it was answered
 			// elsewhere. Surfacing can block on a full results buffer, and
 			// the countdown must not start while the call is still queued.
-			func() {
+			if err := func() error {
 				defer r.idle.unblock(p.id())
-				if r.isAnswered(p.id()) {
-					return
+				if r.isSettled(p.id()) {
+					return nil
 				}
-				r.surfaceCall(ctx, r.execute(ctx, p))
-			}()
+				call, surface, err := r.execute(ctx, p)
+				if surface {
+					r.surfaceCall(ctx, call)
+				}
+				return err
+			}(); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -1029,7 +1091,7 @@ func (r *SessionToolRunner) idleWatchdog(ctx context.Context) error {
 // the matching result event (user.tool_result for an agent.tool_use,
 // user.custom_tool_result for an agent.custom_tool_use), and returns the
 // DispatchedToolCall to be yielded.
-func (r *SessionToolRunner) execute(ctx context.Context, p pendingToolUse) DispatchedToolCall {
+func (r *SessionToolRunner) execute(ctx context.Context, p pendingToolUse) (DispatchedToolCall, bool, error) {
 	id, name := p.id(), p.name()
 	log := r.log.With(
 		slog.String("tool", name),
@@ -1049,12 +1111,22 @@ func (r *SessionToolRunner) execute(ctx context.Context, p pendingToolUse) Dispa
 		Name:          name,
 		Confirmation:  p.confirmation,
 	}
+	callCtx, cancelCall := context.WithCancel(ctx)
+	if !r.startCall(id, cancelCall) {
+		cancelCall()
+		return call, false, nil
+	}
+	defer func() {
+		r.finishCall(id)
+		cancelCall()
+	}()
 
 	rawInput, err := json.Marshal(p.input())
 	if err != nil {
 		log.Warn("re-encoding tool input failed", slog.Any("error", err))
 		call.IsError = true
-		return r.postCall(ctx, call, textOnlyResult(fmt.Sprintf("tool input could not be re-encoded: %v", err)))
+		call, err = r.postCall(callCtx, call, textOnlyResult(fmt.Sprintf("tool input could not be re-encoded: %v", err)))
+		return call, true, err
 	}
 
 	var blocks []BetaToolResultBlockParamContentUnion
@@ -1071,18 +1143,22 @@ func (r *SessionToolRunner) execute(ctx context.Context, p pendingToolUse) Dispa
 		// keeps it out of the idle/end-turn accounting and re-surfaces it
 		// after a reconnect until its owner answers it.
 		log.Info("tool not owned by this runner; leaving the tool_use_id pending for its owner")
-		return call
+		return call, true, nil
 	} else {
 		// Derive the per-tool timeout from the runner ctx (not
 		// context.WithoutCancel) so cancelling the runner also aborts an
 		// in-flight tool instead of leaving it to run out the full timeout
 		// while teardown blocks on the drain.
 		toolTimeout := r.toolTimeout()
-		toolCtx, cancel := context.WithTimeout(ctx, toolTimeout)
+		toolCtx, cancel := context.WithTimeout(callCtx, toolTimeout)
 		out, runErr := tool.Execute(toolCtx, rawInput)
+		toolCtxErr := toolCtx.Err()
 		cancel()
+		if r.isCanceled(id) {
+			return call, true, nil
+		}
 		switch {
-		case errors.Is(toolCtx.Err(), context.DeadlineExceeded):
+		case errors.Is(toolCtxErr, context.DeadlineExceeded):
 			call.IsError = true
 			blocks = textOnlyResult(fmt.Sprintf("tool %q timed out after %s", name, toolTimeout))
 		case runErr != nil:
@@ -1096,7 +1172,8 @@ func (r *SessionToolRunner) execute(ctx context.Context, p pendingToolUse) Dispa
 	if len(blocks) == 0 {
 		blocks = textOnlyResult("(no output)")
 	}
-	return r.postCall(ctx, call, blocks)
+	call, err = r.postCall(callCtx, call, blocks)
+	return call, true, err
 }
 
 // textOnlyResult wraps s as a single text tool-result block.
@@ -1163,9 +1240,13 @@ func toCustomToolResultContent(blocks []BetaToolResultBlockParamContentUnion) []
 // when call.Custom, otherwise user.tool_result — from the tool's result blocks,
 // sends it, and records the event on call.Result / call.CustomResult and the
 // send outcome on call.Posted. The tool-use id is marked answered ONLY when
-// the result post actually succeeds: a failed post leaves the call unanswered
-// so the next reconcile re-dispatches it instead of silently dropping it.
-func (r *SessionToolRunner) postCall(ctx context.Context, call DispatchedToolCall, blocks []BetaToolResultBlockParamContentUnion) DispatchedToolCall {
+// the result post actually succeeds. Transient send exhaustion leaves the call
+// pending for reconcile; a permanent rejection is returned as a terminal
+// runner error.
+func (r *SessionToolRunner) postCall(ctx context.Context, call DispatchedToolCall, blocks []BetaToolResultBlockParamContentUnion) (DispatchedToolCall, error) {
+	if r.isSettled(call.ToolUseID) {
+		return call, nil
+	}
 	var event BetaManagedAgentsEventParamsUnion
 	if call.Custom {
 		call.CustomResult = BetaManagedAgentsUserCustomToolResultEventParams{
@@ -1184,38 +1265,59 @@ func (r *SessionToolRunner) postCall(ctx context.Context, call DispatchedToolCal
 		}
 		event = BetaManagedAgentsEventParamsUnion{OfUserToolResult: &call.Result}
 	}
-	call.Posted = r.sendResult(ctx, event, call.ToolUseID)
+	var err error
+	call.Posted, err = r.sendResult(ctx, event, call.ToolUseID)
+	if err != nil {
+		return call, err
+	}
 	if call.Posted {
 		r.markAnswered(call.ToolUseID)
 	}
-	return call
+	return call, nil
 }
 
 // sendResult posts a tool-result event (user.tool_result or
 // user.custom_tool_result). Returns true on success. Retries up to
 // sessionRunnerSendRetries times on transient failures, backing off between
 // attempts but NOT after the final one; a permanent 4xx short-circuits and
-// returns false.
-func (r *SessionToolRunner) sendResult(ctx context.Context, event BetaManagedAgentsEventParamsUnion, toolUseID string) bool {
+// returns a terminal error so the worker releases the session instead of
+// redispatching an unrecoverable call forever.
+func (r *SessionToolRunner) sendResult(ctx context.Context, event BetaManagedAgentsEventParamsUnion, toolUseID string) (bool, error) {
 	params := BetaSessionEventSendParams{
 		Events: []BetaManagedAgentsEventParamsUnion{event},
 	}
 	for attempt := range sessionRunnerSendRetries {
+		if r.isSettled(toolUseID) {
+			return false, nil
+		}
 		sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.sendTimeout())
 		_, err := r.eventService.Send(sendCtx, r.sessionID, params, r.reqOpts...)
 		cancel()
 		if err == nil {
-			return true
+			return true, nil
 		}
-		if isFatal4xxStatus(err) {
-			r.log.Error("tool result send hit permanent 4xx; not retrying",
-				slog.String("tool_use_id", toolUseID), slog.Any("error", err))
-			return false
+		if r.isSettled(toolUseID) {
+			r.log.Debug("tool result send abandoned: call settled elsewhere",
+				slog.String("tool_use_id", toolUseID))
+			return false, nil
 		}
 		if ctx.Err() != nil {
 			r.log.Debug("tool result send abandoned: ctx cancelled",
 				slog.String("tool_use_id", toolUseID))
-			return false
+			return false, nil
+		}
+		if isFatal4xxStatus(err) {
+			if r.refreshRejectedCall(ctx, toolUseID) {
+				r.log.Debug("tool result rejection matched settled history",
+					slog.String("tool_use_id", toolUseID))
+				return false, nil
+			}
+			if ctx.Err() != nil {
+				return false, nil
+			}
+			r.log.Error("tool result send hit permanent 4xx; not retrying",
+				slog.String("tool_use_id", toolUseID), slog.Any("error", err))
+			return false, fmt.Errorf("tool result send: %w", err)
 		}
 		r.log.Warn("tool result send failed; retrying",
 			slog.String("tool_use_id", toolUseID),
@@ -1227,22 +1329,209 @@ func (r *SessionToolRunner) sendResult(ctx context.Context, event BetaManagedAge
 			sleepCtx(ctx, time.Duration(attempt+1)*time.Second)
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (r *SessionToolRunner) markSeen(id string) bool {
+// refreshRejectedCall resolves the race where the server processes an
+// interrupt or another runner's result before the local SSE stream observes it.
+// It is only called after a permanent result rejection, so the extra list
+// request stays off the normal dispatch path.
+func (r *SessionToolRunner) refreshRejectedCall(ctx context.Context, toolUseID string) bool {
+	r.mu.Lock()
+	_, seen := r.seen[toolUseID]
+	r.mu.Unlock()
+	if !seen {
+		return false
+	}
+
+	listCtx, cancel := context.WithTimeout(ctx, r.sendTimeout())
+	defer cancel()
+	pager := r.eventService.ListAutoPaging(listCtx, r.sessionID,
+		BetaSessionEventListParams{
+			Limit: param.NewOpt(int64(1000)),
+			Order: BetaSessionEventListParamsOrderAsc,
+			Types: []string{
+				"user.interrupt",
+				string(BetaManagedAgentsUserToolResultEventTypeUserToolResult),
+				string(BetaManagedAgentsUserCustomToolResultEventTypeUserCustomToolResult),
+			},
+		},
+		r.reqOpts...)
+	var latestGlobalInterruptAt time.Time
+	answeredIDs := map[string]struct{}{}
+	for pager.Next() {
+		ev := pager.Current()
+		switch ev.Type {
+		case "user.interrupt":
+			if ev.SessionThreadID == "" && ev.ProcessedAt.After(latestGlobalInterruptAt) {
+				latestGlobalInterruptAt = ev.ProcessedAt
+			}
+		case string(BetaManagedAgentsUserToolResultEventTypeUserToolResult):
+			answeredIDs[ev.ToolUseID] = struct{}{}
+		case string(BetaManagedAgentsUserCustomToolResultEventTypeUserCustomToolResult):
+			answeredIDs[ev.CustomToolUseID] = struct{}{}
+		}
+	}
+
+	r.eventMu.Lock()
+	answeredAdvanced := false
+	for id := range answeredIDs {
+		if r.markAnswered(id) {
+			answeredAdvanced = true
+		}
+	}
+	var canceledIDs []string
+	var cancelActive context.CancelFunc
+	interruptAdvanced := false
+	if !latestGlobalInterruptAt.IsZero() {
+		var ok bool
+		canceledIDs, cancelActive, ok, interruptAdvanced = r.recordGlobalInterrupt(latestGlobalInterruptAt, "")
+		if !ok {
+			interruptAdvanced = false
+		}
+	}
+	if answeredAdvanced || interruptAdvanced {
+		// These non-idle events have not reached the local stream yet. Clear
+		// stale idle state before retiring blockers; a later idle event arms a
+		// fresh countdown. eventMu prevents a stream idle from racing past this.
+		r.idle.disarm()
+	}
+	if cancelActive != nil {
+		cancelActive()
+	}
+	// awaitingConfirmation belongs to the stream goroutine. Retire blockers
+	// here; the next stream/reconcile pass removes the corresponding map entries.
+	for id := range answeredIDs {
+		r.idle.unblock(id)
+	}
+	for _, id := range canceledIDs {
+		r.idle.unblock(id)
+	}
+	r.eventMu.Unlock()
+
+	if err := pager.Err(); err != nil {
+		r.log.Warn("tool result rejection history check failed",
+			slog.String("tool_use_id", toolUseID), slog.Any("error", err))
+	}
+	return r.isSettled(toolUseID)
+}
+
+func (r *SessionToolRunner) markSeen(id string, processedAt time.Time) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.seen[id]; ok {
 		return false
 	}
-	r.seen[id] = struct{}{}
+	r.seen[id] = processedAt
+	if !r.latestGlobalInterruptAt.IsZero() && !processedAt.After(r.latestGlobalInterruptAt) {
+		r.canceled[id] = struct{}{}
+	}
 	return true
 }
 
-func (r *SessionToolRunner) markAnswered(id string) {
+func (r *SessionToolRunner) markAnswered(id string) bool {
+	r.mu.Lock()
+	_, existed := r.answered[id]
+	r.answered[id] = struct{}{}
+	r.mu.Unlock()
+	return !existed
+}
+
+// noteAnswered records a result observed from the server and retires any local
+// execution or confirmation hold for the same call. Only the stream goroutine
+// calls this method, so awaitingConfirmation needs no additional lock.
+func (r *SessionToolRunner) noteAnswered(id string) {
 	r.mu.Lock()
 	r.answered[id] = struct{}{}
+	var cancelActive context.CancelFunc
+	if r.activeCallID == id {
+		cancelActive = r.activeCallCancel
+	}
+	r.mu.Unlock()
+
+	if cancelActive != nil {
+		cancelActive()
+	}
+	r.cancelHeldCall(id)
+}
+
+func (r *SessionToolRunner) cancelHeldCall(id string) {
+	if _, held := r.awaitingConfirmation[id]; held {
+		delete(r.awaitingConfirmation, id)
+		delete(r.confirmationVerdicts, id)
+		r.idle.unblock(id)
+	}
+}
+
+// processGlobalInterrupt advances the session-wide processed-time cutoff. Calls
+// at or before the cutoff are no longer accepted by the server, regardless of
+// where they appear in created_at-ordered history.
+func (r *SessionToolRunner) processGlobalInterrupt(processedAt time.Time, sessionThreadID string) {
+	canceledIDs, cancelActive, ok, _ := r.recordGlobalInterrupt(processedAt, sessionThreadID)
+	if !ok {
+		return
+	}
+
+	if cancelActive != nil {
+		cancelActive()
+	}
+	for _, id := range canceledIDs {
+		r.cancelHeldCall(id)
+	}
+}
+
+// recordGlobalInterrupt applies the synchronized portion of a global interrupt
+// transition. It can run from the stream loop or the dispatch-side rejection
+// refresh; stream-owned confirmation maps are cleaned separately.
+func (r *SessionToolRunner) recordGlobalInterrupt(processedAt time.Time, sessionThreadID string) ([]string, context.CancelFunc, bool, bool) {
+	if processedAt.IsZero() || sessionThreadID != "" {
+		return nil, nil, false, false
+	}
+
+	r.mu.Lock()
+	advanced := processedAt.After(r.latestGlobalInterruptAt)
+	if advanced {
+		r.latestGlobalInterruptAt = processedAt
+	}
+	var canceledIDs []string
+	for id, callProcessedAt := range r.seen {
+		if callProcessedAt.After(r.latestGlobalInterruptAt) {
+			continue
+		}
+		if _, answered := r.answered[id]; answered {
+			continue
+		}
+		r.canceled[id] = struct{}{}
+		canceledIDs = append(canceledIDs, id)
+	}
+	var cancelActive context.CancelFunc
+	if _, canceled := r.canceled[r.activeCallID]; canceled {
+		cancelActive = r.activeCallCancel
+	}
+	r.mu.Unlock()
+	return canceledIDs, cancelActive, true, advanced
+}
+
+func (r *SessionToolRunner) startCall(id string, cancel context.CancelFunc) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, answered := r.answered[id]; answered {
+		return false
+	}
+	if _, canceled := r.canceled[id]; canceled {
+		return false
+	}
+	r.activeCallID = id
+	r.activeCallCancel = cancel
+	return true
+}
+
+func (r *SessionToolRunner) finishCall(id string) {
+	r.mu.Lock()
+	if r.activeCallID == id {
+		r.activeCallID = ""
+		r.activeCallCancel = nil
+	}
 	r.mu.Unlock()
 }
 
@@ -1253,12 +1542,30 @@ func (r *SessionToolRunner) isAnswered(id string) bool {
 	return ok
 }
 
+func (r *SessionToolRunner) isSettled(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, answered := r.answered[id]
+	_, canceled := r.canceled[id]
+	return answered || canceled
+}
+
+func (r *SessionToolRunner) isCanceled(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, canceled := r.canceled[id]
+	return canceled
+}
+
 // routeToolEvent enqueues p for dispatch, honoring its evaluated permission.
 // A call the server gated with "ask" (or any unrecognized permission — fail
 // closed) is held until its user.tool_confirmation arrives; a call already
 // evaluated to "deny" is resolved as denied regardless of any recorded verdict.
 func (r *SessionToolRunner) routeToolEvent(ctx context.Context, out chan<- pendingToolUse, p pendingToolUse) {
 	id := p.id()
+	if r.isSettled(id) {
+		return
+	}
 	// Only builtin agent.tool_use carries evaluated_permission today; if the
 	// field ever lands on agent.custom_tool_use the gate must keep failing
 	// closed rather than dispatch a gated call by event type.
@@ -1288,6 +1595,11 @@ func (r *SessionToolRunner) routeToolEvent(ctx context.Context, out chan<- pendi
 				slog.String("tool", p.name()), slog.String("tool_use_id", id))
 			r.awaitingConfirmation[id] = p
 			r.idle.block(id)
+			// A dispatch-side history refresh can apply an interrupt between
+			// the initial settled check and this hold registration.
+			if r.isSettled(id) {
+				r.cancelHeldCall(id)
+			}
 		}
 		return
 	}
@@ -1299,6 +1611,9 @@ func (r *SessionToolRunner) routeToolEvent(ctx context.Context, out chan<- pendi
 // never gates, e.g. an agent.mcp_tool_use) is kept in confirmationVerdicts so
 // a later route of that call resolves instantly.
 func (r *SessionToolRunner) noteConfirmation(ctx context.Context, out chan<- pendingToolUse, toolUseID, result string) {
+	if r.isSettled(toolUseID) {
+		return
+	}
 	r.confirmationVerdicts[toolUseID] = result
 	if held, ok := r.awaitingConfirmation[toolUseID]; ok {
 		r.applyVerdict(ctx, out, held, result)
@@ -1352,9 +1667,22 @@ func (r *SessionToolRunner) applyVerdict(ctx context.Context, out chan<- pending
 // early (ctx cancelled). The underlying work already happened; only the
 // observability event is lost.
 func (r *SessionToolRunner) surfaceCall(ctx context.Context, call DispatchedToolCall) {
+	// Prefer an immediately available buffer slot over cancellation. A sibling
+	// loop can terminate the errgroup just as this completed call is surfaced.
 	select {
-	case <-ctx.Done():
 	case r.results <- call:
+		return
+	default:
+	}
+	select {
+	case r.results <- call:
+	case <-ctx.Done():
+		// Cancellation and buffer availability can become ready together.
+		// Preserve the call when possible without blocking shutdown.
+		select {
+		case r.results <- call:
+		default:
+		}
 	}
 }
 

--- a/betasessiontoolrunner_test.go
+++ b/betasessiontoolrunner_test.go
@@ -148,6 +148,21 @@ func idleRequiresActionEvt(id string, eventIDs ...string) map[string]any {
 	}
 }
 
+func interruptEvt(id string, processed bool, sessionThreadID string) map[string]any {
+	event := map[string]any{
+		"type":         "user.interrupt",
+		"id":           id,
+		"processed_at": nil,
+	}
+	if processed {
+		event["processed_at"] = "2026-05-11T12:00:01Z"
+	}
+	if sessionThreadID != "" {
+		event["session_thread_id"] = sessionThreadID
+	}
+	return event
+}
+
 func emptyEventList() string {
 	body, _ := json.Marshal(map[string]any{"data": []any{}, "first_id": nil, "has_more": false, "last_id": nil})
 	return string(body)
@@ -387,48 +402,119 @@ func TestSessionToolRunner_DispatchesBuiltinAndCustom(t *testing.T) {
 	require.Equal(t, int32(2), echo.runs.Load())
 }
 
-// TestSessionToolRunner_ReconcileRetriesFailedPost covers the regression where
-// a tool_use whose result post failed was marked answered anyway and so never
-// retried. The post must only count as answered once it actually succeeds, so
-// the reconcile after a reconnect re-dispatches the still-unanswered call.
-func TestSessionToolRunner_ReconcileRetriesFailedPost(t *testing.T) {
+func TestSessionToolRunner_PermanentResultRejectionTerminates(t *testing.T) {
 	server := newSessionEventsServer(t)
-
-	var streamConns atomic.Int32
 	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
-		if streamConns.Add(1) == 1 {
-			// First connection: deliver the tool_use, then close so the runner
-			// reconnects and reconciles.
-			streamWriter(w, r, []string{
-				sseLine("agent.tool_use", toolUseEvt("evt_1", "echo", map[string]any{})),
-			}, false)
-			return
-		}
-		streamWriter(w, r, nil, true) // later connections: hold open, no events
-	}
-
-	var lists atomic.Int32
-	server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		// The reconcile after the reconnect must still see the unanswered
-		// tool_use in history so it can re-dispatch it.
-		if lists.Add(1) >= 2 {
-			body, _ := json.Marshal(map[string]any{
-				"data":     []any{toolUseEvt("evt_1", "echo", map[string]any{})},
-				"first_id": "evt_1", "has_more": false, "last_id": "evt_1",
-			})
-			_, _ = w.Write(body)
-			return
-		}
-		_, _ = w.Write([]byte(emptyEventList()))
+		streamWriter(w, r, []string{
+			sseLine("agent.tool_use", toolUseEvt("evt_1", "echo", map[string]any{})),
+		}, true)
 	}
 
 	var sends atomic.Int32
 	server.HandleSend = func(w http.ResponseWriter, _ *http.Request) {
+		sends.Add(1)
+		http.Error(w, "bad", http.StatusBadRequest)
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 0)
+
+	require.True(t, r.Next(), "the rejected dispatch remains observable")
+	require.False(t, r.Current().Posted)
+	require.False(t, r.Next(), "a permanent result rejection must stop the runner")
+	require.ErrorContains(t, r.Err(), "tool result send")
+	require.Equal(t, int32(1), echo.runs.Load())
+	require.Equal(t, int32(1), sends.Load())
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_DrainsRejectedCallAfterTerminalCancel(t *testing.T) {
+	server := newSessionEventsServer(t)
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		streamWriter(w, r, []string{
+			sseLine("agent.tool_use", toolUseEvt("evt_ok", "echo", nil)),
+			sseLine("agent.tool_use", toolUseEvt("evt_rejected", "echo", nil)),
+		}, true)
+	}
+	var sends atomic.Int32
+	server.HandleSend = func(w http.ResponseWriter, _ *http.Request) {
 		if sends.Add(1) == 1 {
-			// First post fails permanently — the call must NOT be marked
-			// answered, so the next reconcile retries it.
-			http.Error(w, "bad", http.StatusBadRequest)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(sendOK()))
+			return
+		}
+		http.Error(w, "bad", http.StatusBadRequest)
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 0)
+
+	require.True(t, r.Next())
+	require.Equal(t, "evt_ok", r.Current().ToolUseID)
+	require.True(t, r.Current().Posted)
+	select {
+	case <-r.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("runner did not terminate after permanent result rejection")
+	}
+	require.True(t, r.Next(), "a buffered rejected call must be drained before cancellation ends iteration")
+	require.Equal(t, "evt_rejected", r.Current().ToolUseID)
+	require.False(t, r.Current().Posted)
+	require.False(t, r.Next())
+	require.ErrorContains(t, r.Err(), "tool result send")
+	require.Equal(t, int32(2), echo.runs.Load())
+	require.Equal(t, int32(2), sends.Load())
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_SurfaceCallPrefersBufferAfterCancellation(t *testing.T) {
+	r := &SessionToolRunner{results: make(chan DispatchedToolCall, 1)}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r.surfaceCall(ctx, DispatchedToolCall{ToolUseID: "evt_done"})
+
+	select {
+	case call := <-r.results:
+		require.Equal(t, "evt_done", call.ToolUseID)
+	default:
+		t.Fatal("completed call was dropped despite available result buffer")
+	}
+}
+
+func TestSessionToolRunner_ReconcileRetriesTransientPostFailure(t *testing.T) {
+	server := newSessionEventsServer(t)
+	var streamConns atomic.Int32
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		if streamConns.Add(1) == 1 {
+			streamWriter(w, r, []string{
+				sseLine("agent.tool_use", toolUseEvt("evt_retry", "echo", nil)),
+			}, false)
+			return
+		}
+		streamWriter(w, r, nil, true)
+	}
+	var lists atomic.Int32
+	server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if lists.Add(1) == 1 {
+			_, _ = w.Write([]byte(emptyEventList()))
+			return
+		}
+		body, _ := json.Marshal(map[string]any{
+			"data":     []any{toolUseEvt("evt_retry", "echo", nil)},
+			"first_id": "evt_retry", "has_more": false, "last_id": "evt_retry",
+		})
+		_, _ = w.Write(body)
+	}
+	var sends atomic.Int32
+	server.HandleSend = func(w http.ResponseWriter, _ *http.Request) {
+		if sends.Add(1) <= sessionRunnerSendRetries {
+			http.Error(w, "retry", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -440,18 +526,371 @@ func TestSessionToolRunner_ReconcileRetriesFailedPost(t *testing.T) {
 	defer cancel()
 	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 0)
 
-	require.True(t, r.Next(), "first dispatch should be yielded")
-	first := r.Current()
-	require.Equal(t, "evt_1", first.ToolUseID)
-	require.False(t, first.Posted, "the first result post fails (permanent 4xx)")
-
-	require.True(t, r.Next(), "reconcile after reconnect must re-dispatch the unanswered tool_use")
-	second := r.Current()
-	require.Equal(t, "evt_1", second.ToolUseID)
-	require.True(t, second.Posted, "the retried result post succeeds")
-
-	require.GreaterOrEqual(t, echo.runs.Load(), int32(2), "the tool is re-executed on the retry")
+	require.True(t, r.Next())
+	require.False(t, r.Current().Posted)
+	require.True(t, r.Next())
+	require.True(t, r.Current().Posted)
+	require.Equal(t, int32(2), echo.runs.Load())
+	require.Equal(t, int32(4), sends.Load())
 	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_GlobalInterruptCancelsHeldHistory(t *testing.T) {
+	server := newSessionEventsServer(t)
+	var streamConns atomic.Int32
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		if streamConns.Add(1) == 1 {
+			streamWriter(w, r, []string{
+				sseLine("agent.tool_use", askToolUseEvt("evt_held", "echo", nil, "ask")),
+			}, false)
+			return
+		}
+		streamWriter(w, r, nil, true)
+	}
+
+	var lists atomic.Int32
+	server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if lists.Add(1) == 1 {
+			_, _ = w.Write([]byte(emptyEventList()))
+			return
+		}
+		events := []any{interruptEvt("evt_interrupt", true, ""), idleEndTurnEvt("evt_idle")}
+		body, _ := json.Marshal(map[string]any{
+			"data": events, "first_id": "evt_interrupt", "has_more": false, "last_id": "evt_idle",
+		})
+		_, _ = w.Write(body)
+	}
+	server.HandleSend = func(http.ResponseWriter, *http.Request) {
+		t.Fatal("an interrupted tool call must not post a result")
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 50*time.Millisecond)
+
+	require.False(t, r.Next())
+	require.ErrorIs(t, r.Err(), ErrIdleTimeout)
+	require.Equal(t, int32(0), echo.runs.Load())
+	require.False(t, r.isAnswered("evt_held"))
+	require.True(t, r.isSettled("evt_held"))
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_GlobalInterruptCancelsHeldLiveCall(t *testing.T) {
+	server := newSessionEventsServer(t)
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		streamWriter(w, r, []string{
+			sseLine("agent.tool_use", askToolUseEvt("evt_held", "echo", nil, "ask")),
+			sseLine("user.interrupt", interruptEvt("evt_interrupt", true, "")),
+			sseLine("session.status_idle", idleEndTurnEvt("evt_idle")),
+		}, true)
+	}
+	server.HandleSend = func(http.ResponseWriter, *http.Request) {
+		t.Fatal("an interrupted tool call must not post a result")
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 50*time.Millisecond)
+
+	require.False(t, r.Next())
+	require.ErrorIs(t, r.Err(), ErrIdleTimeout)
+	require.Equal(t, int32(0), echo.runs.Load())
+	require.False(t, r.isAnswered("evt_held"))
+	require.True(t, r.isSettled("evt_held"))
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_GlobalInterruptUsesProcessedTimeCutoff(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolUseID string
+		toolUse   map[string]any
+	}{
+		{
+			name:      "builtin",
+			toolUseID: "evt_stale",
+			toolUse:   toolUseEvt("evt_stale", "echo", nil),
+		},
+		{
+			name:      "custom",
+			toolUseID: "cevt_stale",
+			toolUse:   customToolUseEvt("cevt_stale", "echo", nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newSessionEventsServer(t)
+			server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+				streamWriter(w, r, nil, true)
+			}
+			server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
+				// History is ordered by created_at. A queued interrupt can therefore
+				// appear before a tool call that it later invalidated at processing time.
+				events := []any{interruptEvt("evt_interrupt", true, ""), tt.toolUse, idleEndTurnEvt("evt_idle")}
+				body, _ := json.Marshal(map[string]any{
+					"data": events, "first_id": "evt_interrupt", "has_more": false, "last_id": "evt_idle",
+				})
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(body)
+			}
+			server.HandleSend = func(http.ResponseWriter, *http.Request) {
+				t.Fatal("a tool call before the processed interrupt cutoff must not post a result")
+			}
+
+			echo := &stubBetaTool{name: "echo"}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 50*time.Millisecond)
+
+			require.False(t, r.Next())
+			require.ErrorIs(t, r.Err(), ErrIdleTimeout)
+			require.Equal(t, int32(0), echo.runs.Load())
+			require.True(t, r.isCanceled(tt.toolUseID))
+			require.NoError(t, r.Close())
+		})
+	}
+}
+
+func TestSessionToolRunner_GlobalInterruptCancelsInFlightCall(t *testing.T) {
+	server := newSessionEventsServer(t)
+	started := make(chan struct{})
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = w.Write([]byte(sseLine("agent.tool_use", toolUseEvt("evt_running", "echo", nil))))
+		flusher.Flush()
+		select {
+		case <-started:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte(sseLine("user.interrupt", interruptEvt("evt_interrupt", true, ""))))
+		flusher.Flush()
+		_, _ = w.Write([]byte(sseLine("session.status_idle", idleEndTurnEvt("evt_idle"))))
+		flusher.Flush()
+		<-r.Context().Done()
+	}
+	server.HandleSend = func(http.ResponseWriter, *http.Request) {
+		t.Fatal("an interrupted in-flight tool call must not post a result")
+	}
+
+	echo := &stubBetaTool{name: "echo", run: func(ctx context.Context, _ json.RawMessage) (string, bool) {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err().Error(), true
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 50*time.Millisecond)
+
+	require.True(t, r.Next(), "the interrupted dispatch remains observable")
+	require.Equal(t, "evt_running", r.Current().ToolUseID)
+	require.False(t, r.Current().Posted)
+	require.False(t, r.Next())
+	require.ErrorIs(t, r.Err(), ErrIdleTimeout)
+	require.Equal(t, int32(1), echo.runs.Load())
+	require.True(t, r.isCanceled("evt_running"))
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_PermanentRejectionRefreshesSettlementHistory(t *testing.T) {
+	server := newSessionEventsServer(t)
+	sendStarted := make(chan struct{})
+	releaseIdle := make(chan struct{})
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = w.Write([]byte(sseLine("agent.tool_use", toolUseEvt("evt_race", "echo", nil))))
+		_, _ = w.Write([]byte(sseLine("agent.tool_use", toolUseEvt("evt_queued_answered", "echo", nil))))
+		_, _ = w.Write([]byte(sseLine("agent.tool_use", toolUseEvt("evt_queued_interrupted", "echo", nil))))
+		flusher.Flush()
+		select {
+		case <-sendStarted:
+		case <-r.Context().Done():
+			return
+		}
+		select {
+		case <-releaseIdle:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte(sseLine("session.status_idle", idleEndTurnEvt("evt_idle"))))
+		flusher.Flush()
+		<-r.Context().Done()
+	}
+
+	var lists atomic.Int32
+	server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if lists.Add(1) == 1 {
+			_, _ = w.Write([]byte(emptyEventList()))
+			return
+		}
+		result := map[string]any{
+			"type":         "user.tool_result",
+			"id":           "evt_result",
+			"tool_use_id":  "evt_race",
+			"content":      []any{map[string]any{"type": "text", "text": "answered elsewhere"}},
+			"is_error":     false,
+			"processed_at": "2026-05-11T12:00:01Z",
+		}
+		queuedResult := map[string]any{
+			"type":         "user.tool_result",
+			"id":           "evt_queued_result",
+			"tool_use_id":  "evt_queued_answered",
+			"content":      []any{map[string]any{"type": "text", "text": "answered elsewhere"}},
+			"is_error":     false,
+			"processed_at": "2026-05-11T12:00:01Z",
+		}
+		interrupt := interruptEvt("evt_interrupt", true, "")
+		body, _ := json.Marshal(map[string]any{
+			"data": []any{result, queuedResult, interrupt}, "first_id": "evt_result", "has_more": false, "last_id": "evt_interrupt",
+		})
+		_, _ = w.Write(body)
+	}
+	var sends atomic.Int32
+	server.HandleSend = func(w http.ResponseWriter, _ *http.Request) {
+		if sends.Add(1) == 1 {
+			close(sendStarted)
+		}
+		http.Error(w, "interrupted", http.StatusBadRequest)
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	runner := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 50*time.Millisecond)
+
+	require.True(t, runner.Next(), "the interrupted dispatch remains observable")
+	require.False(t, runner.Current().Posted)
+	close(releaseIdle)
+	require.False(t, runner.Next())
+	require.ErrorIs(t, runner.Err(), ErrIdleTimeout)
+	require.Equal(t, int32(1), echo.runs.Load())
+	require.Equal(t, int32(1), sends.Load())
+	require.Equal(t, int32(2), lists.Load())
+	require.True(t, runner.isAnswered("evt_race"))
+	require.False(t, runner.isCanceled("evt_race"))
+	require.True(t, runner.isAnswered("evt_queued_answered"))
+	require.False(t, runner.isCanceled("evt_queued_answered"))
+	require.True(t, runner.isCanceled("evt_queued_interrupted"))
+	require.NoError(t, runner.Close())
+}
+
+func TestSessionToolRunner_ExternalResultReleasesConfirmationHold(t *testing.T) {
+	server := newSessionEventsServer(t)
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		result := map[string]any{
+			"type":         "user.tool_result",
+			"id":           "evt_result",
+			"tool_use_id":  "evt_held",
+			"content":      []any{map[string]any{"type": "text", "text": "answered elsewhere"}},
+			"is_error":     false,
+			"processed_at": "2026-05-11T12:00:01Z",
+		}
+		streamWriter(w, r, []string{
+			sseLine("agent.tool_use", askToolUseEvt("evt_held", "echo", nil, "ask")),
+			sseLine("user.tool_result", result),
+			sseLine("session.status_idle", idleEndTurnEvt("evt_idle")),
+		}, true)
+	}
+	server.HandleSend = func(http.ResponseWriter, *http.Request) {
+		t.Fatal("a tool call answered elsewhere must not post another result")
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 50*time.Millisecond)
+
+	require.False(t, r.Next())
+	require.ErrorIs(t, r.Err(), ErrIdleTimeout)
+	require.Equal(t, int32(0), echo.runs.Load())
+	require.True(t, r.isAnswered("evt_held"))
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_HistoryInterruptIsNotReappliedFromStream(t *testing.T) {
+	server := newSessionEventsServer(t)
+	interrupt := interruptEvt("evt_interrupt", true, "")
+	server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+		streamWriter(w, r, []string{sseLine("user.interrupt", interrupt)}, true)
+	}
+	server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
+		tool := toolUseEvt("evt_after", "echo", nil)
+		tool["processed_at"] = "2026-05-11T12:00:02Z"
+		body, _ := json.Marshal(map[string]any{
+			"data": []any{interrupt, tool}, "first_id": "evt_interrupt", "has_more": false, "last_id": "evt_after",
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}
+	var sends atomic.Int32
+	server.HandleSend = func(w http.ResponseWriter, _ *http.Request) {
+		sends.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sendOK()))
+	}
+
+	echo := &stubBetaTool{name: "echo"}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 0)
+
+	require.True(t, r.Next())
+	require.Equal(t, "evt_after", r.Current().ToolUseID)
+	require.True(t, r.Current().Posted)
+	require.Equal(t, int32(1), echo.runs.Load())
+	require.Equal(t, int32(1), sends.Load())
+	require.NoError(t, r.Close())
+}
+
+func TestSessionToolRunner_DoesNotCancelForTargetedOrQueuedInterrupt(t *testing.T) {
+	tests := map[string]map[string]any{
+		"targeted": interruptEvt("evt_interrupt", true, "sthr_other"),
+		"queued":   interruptEvt("evt_interrupt", false, ""),
+	}
+	for name, interrupt := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := newSessionEventsServer(t)
+			server.HandleStream = func(w http.ResponseWriter, r *http.Request) {
+				streamWriter(w, r, nil, true)
+			}
+			server.HandleList = func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				events := []any{toolUseEvt("evt_live", "echo", nil), interrupt, idleEndTurnEvt("evt_idle")}
+				body, _ := json.Marshal(map[string]any{
+					"data": events, "first_id": "evt_live", "has_more": false, "last_id": "evt_idle",
+				})
+				_, _ = w.Write(body)
+			}
+			var sends atomic.Int32
+			server.HandleSend = func(w http.ResponseWriter, _ *http.Request) {
+				sends.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(sendOK()))
+			}
+
+			echo := &stubBetaTool{name: "echo"}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			r := newShortIdleRunner(t, ctx, server.Client(), []BetaTool{echo}, 0)
+
+			require.True(t, r.Next())
+			require.True(t, r.Current().Posted)
+			require.Equal(t, int32(1), echo.runs.Load())
+			require.Equal(t, int32(1), sends.Load())
+			require.NoError(t, r.Close())
+		})
+	}
 }
 
 // TestSessionToolRunner_SkipsUnownedToolByDefault pins the default


### PR DESCRIPTION
Fixes #393.

## Summary

Prevent `SessionToolRunner` from repeatedly dispatching tool calls invalidated by a processed session-wide `user.interrupt`.

- track a high-water interrupt cutoff using `processed_at`, rather than relying on `created_at` list order
- settle builtin and custom tool calls at or before that cutoff across live events, reconnect history, queued dispatches, confirmation holds, and active execution
- cancel the active tool context when its call is interrupted
- ignore queued interrupts and interrupts targeted at another session thread
- re-check settlement history after a permanent result rejection, covering the race where the server processes an interrupt or another runner's result before the local SSE stream observes it
- preserve reconcile retries for transient send failures, but terminate the runner for an unresolved permanent 4xx so an unrecoverable call cannot be dispatched forever
- preserve completed/rejected dispatch records when runner cancellation races with result buffering

Session event history is sorted by `created_at`. Because a queued user interrupt receives `processed_at` later, an invalidated tool call can appear after the interrupt in listed history. The runner therefore stores each tool call's processing timestamp and applies the latest processed global interrupt as a cutoff.

The history refresh on permanent 4xx only runs on the exceptional path. It records all tool results and the latest processed global interrupt before deciding whether the rejected call was settled elsewhere.

The empty-output 400 described in #377 is independent and is handled separately in #394.

## Verification

- `go test -count=1 -run '^(TestSessionToolRunner_|TestIdleClock_)' .`
- `go test -race -count=1 -run '^(TestSessionToolRunner_|TestIdleClock_)' .`
- `go test -count=50 -run 'TestSessionToolRunner_(GlobalInterrupt|PermanentRejectionRefreshesSettlementHistory|ExternalResultReleasesConfirmationHold|DrainsRejectedCall|SurfaceCall)' .`
- `./scripts/lint`
- `go vet . ./tools/agenttoolset`
- `git diff --check`
